### PR TITLE
[Feature] 나의장소 최근경로 구현

### DIFF
--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/dto/BookmarkResponse.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/dto/BookmarkResponse.java
@@ -19,4 +19,6 @@ public class BookmarkResponse {
     private String address;
 
     private String name;
+
+    private int sequence;
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/dto/BookmarkSequenceUpdateRequest.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/dto/BookmarkSequenceUpdateRequest.java
@@ -1,0 +1,7 @@
+package org.programmers.signalbuddyfinal.domain.bookmark.dto;
+
+import jakarta.validation.constraints.Min;
+
+public record BookmarkSequenceUpdateRequest(long id, @Min(1) int targetSequence) {
+
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/entity/Bookmark.java
@@ -1,6 +1,7 @@
 package org.programmers.signalbuddyfinal.domain.bookmark.entity;
 
 import jakarta.persistence.*;
+import java.util.Objects;
 import lombok.*;
 import org.locationtech.jts.geom.Point;
 import org.programmers.signalbuddyfinal.domain.basetime.BaseTimeEntity;
@@ -66,5 +67,13 @@ public class Bookmark extends BaseTimeEntity {
         if (name != null) {
             this.name = name;
         }
+    }
+
+    public void updateSequence(int sequence) {
+        this.sequence = sequence;
+    }
+
+    public boolean isNotOwnedBy(Member member) {
+        return member == null || !Objects.equals(this.member.getMemberId(), member.getMemberId());
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/entity/Bookmark.java
@@ -1,13 +1,26 @@
 package org.programmers.signalbuddyfinal.domain.bookmark.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
 import java.util.Objects;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.locationtech.jts.geom.Point;
 import org.programmers.signalbuddyfinal.domain.basetime.BaseTimeEntity;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
-
-import java.time.LocalDateTime;
+import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
 
 @Entity(name = "bookmarks")
 @Getter
@@ -35,19 +48,12 @@ public class Bookmark extends BaseTimeEntity {
     @Column
     private LocalDateTime deletedAt; // 삭제일
 
-    public void delete() {
-        this.deletedAt = LocalDateTime.now();
-    }
-
-    public boolean isDeleted() {
-        return deletedAt != null;
-    }
-
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @OneToOne(mappedBy = "bookmark")
+    private RecentPath recentPath;
 
     @Builder
     public Bookmark(Point coordinate, String address, Member member, String name) {
@@ -55,6 +61,17 @@ public class Bookmark extends BaseTimeEntity {
         this.address = address;
         this.member = member;
         this.name = name;
+    }
+
+    public void delete() {
+        if (this.recentPath != null) {
+            this.recentPath.unlinkBookmark(); // Bookmark 와의 연관관계 제거
+        }
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
     }
 
     public void update(Point coordinate, String address, String name) {

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepository.java
@@ -1,6 +1,9 @@
 package org.programmers.signalbuddyfinal.domain.bookmark.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.programmers.signalbuddyfinal.domain.bookmark.entity.Bookmark;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +11,9 @@ import org.springframework.stereotype.Repository;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long>,
     BookmarkRepositoryCustom {
 
+    Optional<Bookmark> findTopByMemberOrderBySequenceDesc(Member member);
+
+    List<Bookmark> findAllByBookmarkIdInAndMemberMemberId(List<Long> bookmarkIds, Long id);
+
+    List<Bookmark> findAllBySequenceIn(List<Integer> sequences);
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepository.java
@@ -14,6 +14,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>,
     Optional<Bookmark> findTopByMemberOrderBySequenceDesc(Member member);
 
     List<Bookmark> findAllByBookmarkIdInAndMemberMemberId(List<Long> bookmarkIds, Long id);
-
-    List<Bookmark> findAllBySequenceIn(List<Integer> sequences);
+    List<Bookmark> findAllBySequenceInAndMemberMemberId(List<Integer> targetSequences, Long id);
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepositoryCustomImpl.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepositoryCustomImpl.java
@@ -24,7 +24,7 @@ import static org.programmers.signalbuddyfinal.domain.member.entity.QMember.memb
 public class BookmarkRepositoryCustomImpl implements BookmarkRepositoryCustom {
 
     private static final QBean<BookmarkResponse> pageBookmarkDto = Projections.fields(
-        BookmarkResponse.class, bookmark.bookmarkId, bookmark.address, bookmark.name,
+        BookmarkResponse.class, bookmark.bookmarkId, bookmark.address, bookmark.name, bookmark.sequence,
         Expressions.numberTemplate(Double.class, "ST_X({0})", bookmark.coordinate).as("lng"),
         Expressions.numberTemplate(Double.class, "ST_Y({0})", bookmark.coordinate).as("lat"));
 
@@ -39,6 +39,7 @@ public class BookmarkRepositoryCustomImpl implements BookmarkRepositoryCustom {
         final List<BookmarkResponse> responses = queryFactory.select(pageBookmarkDto).from(bookmark)
             .join(member)
             .on(bookmark.member.eq(member).and(member.memberId.eq(memberId)))
+            .where(bookmark.deletedAt.isNull())
             .offset(pageable.getOffset()).limit(pageable.getPageSize())
             .orderBy(new OrderSpecifier<>(Order.ASC, bookmark.bookmarkId)).fetch();
 

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepositoryCustomImpl.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepositoryCustomImpl.java
@@ -41,7 +41,7 @@ public class BookmarkRepositoryCustomImpl implements BookmarkRepositoryCustom {
             .on(bookmark.member.eq(member).and(member.memberId.eq(memberId)))
             .where(bookmark.deletedAt.isNull())
             .offset(pageable.getOffset()).limit(pageable.getPageSize())
-            .orderBy(new OrderSpecifier<>(Order.ASC, bookmark.bookmarkId)).fetch();
+            .orderBy(new OrderSpecifier<>(Order.ASC, bookmark.sequence)).fetch();
 
         final Long count = queryFactory.select(bookmark.count()).from(bookmark).join(member)
             .on(bookmark.member.eq(member).and(member.memberId.eq(memberId)))

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/service/BookmarkService.java
@@ -1,5 +1,10 @@
 package org.programmers.signalbuddyfinal.domain.bookmark.service;
 
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
@@ -7,6 +12,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkRequest;
 import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkResponse;
+import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkSequenceUpdateRequest;
 import org.programmers.signalbuddyfinal.domain.bookmark.entity.Bookmark;
 import org.programmers.signalbuddyfinal.domain.bookmark.exception.BookmarkErrorCode;
 import org.programmers.signalbuddyfinal.domain.bookmark.mapper.BookmarkMapper;
@@ -14,15 +20,12 @@ import org.programmers.signalbuddyfinal.domain.bookmark.repository.BookmarkRepos
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.exception.MemberErrorCode;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
-import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
 import org.programmers.signalbuddyfinal.global.dto.PageResponse;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Objects;
 
 @Slf4j
 @Service
@@ -39,50 +42,53 @@ public class BookmarkService {
         return new PageResponse<>(page);
     }
 
-    public BookmarkResponse createBookmark(BookmarkRequest createRequest, CustomUser2Member user) {
-        final Member member = getMember(user);
+    public BookmarkResponse createBookmark(BookmarkRequest request, Long memberId) {
+        final Member member = getMember(memberId);
 
-        final Point point = toPoint(createRequest.getLng(), createRequest.getLat());
+        final Point point = toPoint(request.getLng(), request.getLat());
+        final int nextSequence =
+            bookmarkRepository.findTopByMemberOrderBySequenceDesc(member).map(Bookmark::getSequence)
+                .orElse(0) + 1;
 
-        final Bookmark bookmark = BookmarkMapper.INSTANCE.toEntity(createRequest, point, member);
+        final Bookmark bookmark = BookmarkMapper.INSTANCE.toEntity(request, point, member);
+        bookmark.updateSequence(nextSequence);
         final Bookmark save = bookmarkRepository.save(bookmark);
         return BookmarkMapper.INSTANCE.toDto(save);
     }
 
     @Transactional
-    public BookmarkResponse updateBookmark(BookmarkRequest updateRequest, Long id,
-        CustomUser2Member user) {
-        final Member member = getMember(user);
+    public BookmarkResponse updateBookmark(BookmarkRequest request, Long id, Long memberId) {
+        final Member member = getMember(memberId);
 
         final Bookmark bookmark = bookmarkRepository.findById(id)
             .orElseThrow(() -> new BusinessException(BookmarkErrorCode.NOT_FOUND_BOOKMARK));
 
-        if (!Objects.equals(member.getMemberId(), bookmark.getMember().getMemberId())) {
+        if (bookmark.isNotOwnedBy(member)) {
             throw new BusinessException(BookmarkErrorCode.UNAUTHORIZED_MEMBER_ACCESS);
         }
 
-        final Point point = toPoint(updateRequest.getLng(), updateRequest.getLat());
+        final Point point = toPoint(request.getLng(), request.getLat());
 
-        bookmark.update(point, updateRequest.getAddress(), updateRequest.getName());
+        bookmark.update(point, request.getAddress(), request.getName());
         return BookmarkMapper.INSTANCE.toDto(bookmark);
     }
 
     @Transactional
-    public void deleteBookmark(Long id, CustomUser2Member user) {
-        final Member member = getMember(user);
+    public void deleteBookmark(List<Long> bookmarkIds, Long memberId) {
+        final Member member = getMember(memberId);
+        final List<Bookmark> bookmarkList = bookmarkRepository.findAllById(bookmarkIds);
+        bookmarkList.forEach(bookmark -> {
+            if (bookmark.isNotOwnedBy(member)) {
+                throw new BusinessException(BookmarkErrorCode.UNAUTHORIZED_MEMBER_ACCESS);
+            }
+            bookmark.delete();
+        });
 
-        final Bookmark bookmark = bookmarkRepository.findById(id)
-            .orElseThrow(() -> new BusinessException(BookmarkErrorCode.NOT_FOUND_BOOKMARK));
-
-        if (!Objects.equals(member.getMemberId(), bookmark.getMember().getMemberId())) {
-            throw new BusinessException(BookmarkErrorCode.UNAUTHORIZED_MEMBER_ACCESS);
-        }
-
-        bookmarkRepository.delete(bookmark);
+        log.info("Bookmark deleted: {}", bookmarkIds);
     }
 
-    private Member getMember(CustomUser2Member user) {
-        return memberRepository.findById(user.getMemberId())
+    private Member getMember(Long id) {
+        return memberRepository.findById(id)
             .orElseThrow(() -> new BusinessException(MemberErrorCode.NOT_FOUND_MEMBER));
     }
 
@@ -93,9 +99,56 @@ public class BookmarkService {
         return geometryFactory.createPoint(new Coordinate(lng, lat));
     }
 
-    public BookmarkResponse getBookmark(Long bookmarkId) {
+    @Transactional(readOnly = true)
+    public BookmarkResponse getBookmark(Long id, Long bookmarkId) {
+        final Member member = getMember(id);
         final Bookmark bookmark = bookmarkRepository.findById(bookmarkId)
             .orElseThrow(() -> new BusinessException(BookmarkErrorCode.NOT_FOUND_BOOKMARK));
+        if (bookmark.isNotOwnedBy(member)) {
+            throw new BusinessException(BookmarkErrorCode.UNAUTHORIZED_MEMBER_ACCESS);
+        }
         return BookmarkMapper.INSTANCE.toDto(bookmark);
+    }
+
+    @Transactional
+    public List<BookmarkResponse> updateBookmarkSequences(Long id,
+        @Valid List<BookmarkSequenceUpdateRequest> requests) {
+        final List<Long> bookmarkIds = requests.stream().map(BookmarkSequenceUpdateRequest::id)
+            .toList();
+        final List<Integer> targetSequences = requests.stream()
+            .map(BookmarkSequenceUpdateRequest::targetSequence).toList();
+
+        // 북마크 ID로 목록 조회
+        final List<Bookmark> bookmarks = bookmarkRepository.findAllByBookmarkIdInAndMemberMemberId(
+            bookmarkIds, id);
+
+        // Target Sequence 로 목록 조회
+        final List<Bookmark> targetBookmarks = bookmarkRepository.findAllBySequenceInAndMemberMemberId(
+            targetSequences, id);
+
+        // id -> Bookmark 매핑
+        final Map<Long, Bookmark> bookmarkMap = bookmarks.stream()
+            .collect(Collectors.toMap(Bookmark::getBookmarkId, Function.identity()));
+        // sequence -> bookmark 매핑
+        final Map<Integer, Bookmark> sequenceMap = targetBookmarks.stream()
+            .collect(Collectors.toMap(Bookmark::getSequence, Function.identity()));
+
+        for (BookmarkSequenceUpdateRequest request : requests) {
+            final Bookmark bookmark = bookmarkMap.get(request.id());
+            final Bookmark targetBookmark = sequenceMap.get(request.targetSequence());
+
+            if (bookmark == null) {
+                throw new BusinessException(BookmarkErrorCode.NOT_FOUND_BOOKMARK);
+            }
+
+            final int originalSequence = bookmark.getSequence();
+            final int targetSequence = targetBookmark.getSequence();
+
+            // sequence 값 변경 (스왑)
+            bookmark.updateSequence(targetSequence);
+            targetBookmark.updateSequence(originalSequence);
+        }
+
+        return bookmarks.stream().map(BookmarkMapper.INSTANCE::toDto).toList();
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/service/BookmarkService.java
@@ -15,6 +15,7 @@ import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.exception.MemberErrorCode;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
+import org.programmers.signalbuddyfinal.global.dto.PageResponse;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,8 +33,10 @@ public class BookmarkService {
     private final GeometryFactory geometryFactory;
     private final MemberRepository memberRepository;
 
-    public Page<BookmarkResponse> findPagedBookmarks(Pageable pageable, Long memberId) {
-        return bookmarkRepository.findPagedByMember(pageable, memberId);
+    public PageResponse<BookmarkResponse> findPagedBookmarks(Pageable pageable, Long memberId) {
+        final Page<BookmarkResponse> page = bookmarkRepository.findPagedByMember(pageable,
+            memberId);
+        return new PageResponse<>(page);
     }
 
     public BookmarkResponse createBookmark(BookmarkRequest createRequest, CustomUser2Member user) {

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
@@ -1,9 +1,13 @@
 package org.programmers.signalbuddyfinal.domain.member.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkRequest;
 import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkResponse;
+import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkSequenceUpdateRequest;
 import org.programmers.signalbuddyfinal.domain.bookmark.service.BookmarkService;
 import org.programmers.signalbuddyfinal.domain.feedback.dto.FeedbackResponse;
 import org.programmers.signalbuddyfinal.domain.feedback.service.FeedbackService;
@@ -13,9 +17,9 @@ import org.programmers.signalbuddyfinal.domain.member.service.MemberService;
 import org.programmers.signalbuddyfinal.global.dto.PageResponse;
 import org.programmers.signalbuddyfinal.global.response.ApiResponse;
 import org.springframework.core.io.Resource;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -87,18 +91,57 @@ public class MemberController {
     }
 
     @GetMapping("{id}/feedbacks")
-    public ResponseEntity<ApiResponse<PageResponse<FeedbackResponse>>> getFeedbacks(@PathVariable Long id,
-        @PageableDefault(page = 0, size = 10) Pageable pageable) {
-        final PageResponse<FeedbackResponse> feedbacks = feedbackService.findPagedExcludingMember(id,
-            pageable);
+    public ResponseEntity<ApiResponse<PageResponse<FeedbackResponse>>> getFeedbacks(
+        @PathVariable Long id, @PageableDefault(page = 0, size = 10) Pageable pageable) {
+        final PageResponse<FeedbackResponse> feedbacks = feedbackService.findPagedExcludingMember(
+            id, pageable);
         return ResponseEntity.ok(ApiResponse.createSuccess(feedbacks));
     }
 
     @GetMapping("{id}/bookmarks")
-    public ResponseEntity<ApiResponse<PageResponse<BookmarkResponse>>> getBookmarks(@PathVariable Long id,
-        @PageableDefault(page = 0, size = 10) Pageable pageable) {
-        final PageResponse<BookmarkResponse> bookmarks = bookmarkService.findPagedBookmarks(pageable,
-            id);
+    public ResponseEntity<ApiResponse<PageResponse<BookmarkResponse>>> getBookmarks(
+        @PathVariable Long id, @PageableDefault(page = 0, size = 10) Pageable pageable) {
+        final PageResponse<BookmarkResponse> bookmarks = bookmarkService.findPagedBookmarks(
+            pageable, id);
         return ResponseEntity.ok(ApiResponse.createSuccess(bookmarks));
+    }
+
+    @PostMapping("{id}/bookmarks")
+    public ResponseEntity<ApiResponse<BookmarkResponse>> saveBookmark(@PathVariable Long id,
+        @RequestBody @Valid BookmarkRequest bookmarkRequest) {
+        final BookmarkResponse saved = bookmarkService.createBookmark(bookmarkRequest, id);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccess(saved));
+    }
+
+    @GetMapping("{id}/bookmarks/{bookmarkId}")
+    public ResponseEntity<ApiResponse<BookmarkResponse>> getBookmark(@PathVariable Long id,
+        @PathVariable Long bookmarkId) {
+        final BookmarkResponse bookmark = bookmarkService.getBookmark(id, bookmarkId);
+        return ResponseEntity.ok(ApiResponse.createSuccess(bookmark));
+    }
+
+    @PatchMapping("{id}/bookmarks/{bookmarkId}")
+    public ResponseEntity<ApiResponse<BookmarkResponse>> updateBookmark(@PathVariable Long id,
+        @PathVariable Long bookmarkId,
+        @RequestBody @Valid BookmarkRequest bookmarkRequest) {
+        final BookmarkResponse updated = bookmarkService.updateBookmark(bookmarkRequest,
+            bookmarkId, id);
+        return ResponseEntity.ok(ApiResponse.createSuccess(updated));
+    }
+
+    @DeleteMapping("{id}/bookmarks")
+    public ResponseEntity<ApiResponse<Object>> deleteBookmark(@PathVariable Long id,
+        @RequestParam List<Long> bookmarkIds) {
+        bookmarkService.deleteBookmark(bookmarkIds, id);
+        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+    }
+
+    @PatchMapping("{id}/bookmarks/sequence/reorder")
+    public ResponseEntity<ApiResponse<List<BookmarkResponse>>> updateBookmarkSequences(
+        @PathVariable Long id,
+        @RequestBody @Valid List<BookmarkSequenceUpdateRequest> requests) {
+        final List<BookmarkResponse> updated = bookmarkService.updateBookmarkSequences(id,
+            requests);
+        return ResponseEntity.ok(ApiResponse.createSuccess(updated));
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
@@ -61,9 +61,9 @@ public class MemberController {
     }
 
     @DeleteMapping("{id}")
-    public ResponseEntity<ApiResponse<MemberResponse>> deleteMember(@PathVariable Long id) {
-        final MemberResponse deleted = memberService.deleteMember(id);
-        return ResponseEntity.ok(ApiResponse.createSuccess(deleted));
+    public ResponseEntity<ApiResponse<Object>> deleteMember(@PathVariable Long id) {
+        memberService.deleteMember(id);
+        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
     }
 
     @PostMapping("{id}/verify-password")

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
@@ -14,6 +14,9 @@ import org.programmers.signalbuddyfinal.domain.feedback.service.FeedbackService;
 import org.programmers.signalbuddyfinal.domain.member.dto.MemberResponse;
 import org.programmers.signalbuddyfinal.domain.member.dto.MemberUpdateRequest;
 import org.programmers.signalbuddyfinal.domain.member.service.MemberService;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathRequest;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
+import org.programmers.signalbuddyfinal.domain.recentpath.service.RecentPathService;
 import org.programmers.signalbuddyfinal.global.dto.PageResponse;
 import org.programmers.signalbuddyfinal.global.response.ApiResponse;
 import org.springframework.core.io.Resource;
@@ -42,6 +45,7 @@ public class MemberController {
     private final MemberService memberService;
     private final FeedbackService feedbackService;
     private final BookmarkService bookmarkService;
+    private final RecentPathService recentPathService;
 
     @GetMapping("{id}")
     public ResponseEntity<ApiResponse<MemberResponse>> findById(@PathVariable Long id) {
@@ -122,10 +126,9 @@ public class MemberController {
 
     @PatchMapping("{id}/bookmarks/{bookmarkId}")
     public ResponseEntity<ApiResponse<BookmarkResponse>> updateBookmark(@PathVariable Long id,
-        @PathVariable Long bookmarkId,
-        @RequestBody @Valid BookmarkRequest bookmarkRequest) {
-        final BookmarkResponse updated = bookmarkService.updateBookmark(bookmarkRequest,
-            bookmarkId, id);
+        @PathVariable Long bookmarkId, @RequestBody @Valid BookmarkRequest bookmarkRequest) {
+        final BookmarkResponse updated = bookmarkService.updateBookmark(bookmarkRequest, bookmarkId,
+            id);
         return ResponseEntity.ok(ApiResponse.createSuccess(updated));
     }
 
@@ -138,10 +141,16 @@ public class MemberController {
 
     @PatchMapping("{id}/bookmarks/sequence/reorder")
     public ResponseEntity<ApiResponse<List<BookmarkResponse>>> updateBookmarkSequences(
-        @PathVariable Long id,
-        @RequestBody @Valid List<BookmarkSequenceUpdateRequest> requests) {
+        @PathVariable Long id, @RequestBody @Valid List<BookmarkSequenceUpdateRequest> requests) {
         final List<BookmarkResponse> updated = bookmarkService.updateBookmarkSequences(id,
             requests);
         return ResponseEntity.ok(ApiResponse.createSuccess(updated));
+    }
+
+    @PostMapping("{id}/recent-path")
+    public ResponseEntity<ApiResponse<RecentPathResponse>> saveRecentPath(@PathVariable Long id,
+        @RequestBody RecentPathRequest request) {
+        final RecentPathResponse response = recentPathService.saveRecentPath(id, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccess(response));
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
@@ -153,4 +153,12 @@ public class MemberController {
         final RecentPathResponse response = recentPathService.saveRecentPath(id, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccess(response));
     }
+
+    @GetMapping("{id}/recent-path")
+    public ResponseEntity<ApiResponse<List<RecentPathResponse>>> getRecentPathList(
+        @PathVariable Long id) {
+        final List<RecentPathResponse> recentPathList = recentPathService.getRecentPathList(id);
+        return ResponseEntity.ok(ApiResponse.createSuccess(recentPathList));
+    }
+
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
@@ -3,6 +3,8 @@ package org.programmers.signalbuddyfinal.domain.member.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkResponse;
+import org.programmers.signalbuddyfinal.domain.bookmark.service.BookmarkService;
 import org.programmers.signalbuddyfinal.domain.feedback.dto.FeedbackResponse;
 import org.programmers.signalbuddyfinal.domain.feedback.service.FeedbackService;
 import org.programmers.signalbuddyfinal.domain.member.dto.MemberResponse;
@@ -14,7 +16,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,6 +37,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final FeedbackService feedbackService;
+    private final BookmarkService bookmarkService;
 
     @GetMapping("{id}")
     public ResponseEntity<ApiResponse<MemberResponse>> findById(@PathVariable Long id) {
@@ -90,5 +92,13 @@ public class MemberController {
         final PageResponse<FeedbackResponse> feedbacks = feedbackService.findPagedExcludingMember(id,
             pageable);
         return ResponseEntity.ok(ApiResponse.createSuccess(feedbacks));
+    }
+
+    @GetMapping("{id}/bookmarks")
+    public ResponseEntity<ApiResponse<PageResponse<BookmarkResponse>>> getBookmarks(@PathVariable Long id,
+        @PageableDefault(page = 0, size = 10) Pageable pageable) {
+        final PageResponse<BookmarkResponse> bookmarks = bookmarkService.findPagedBookmarks(pageable,
+            id);
+        return ResponseEntity.ok(ApiResponse.createSuccess(bookmarks));
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/service/MemberService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/service/MemberService.java
@@ -71,11 +71,10 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberResponse deleteMember(Long id) {
+    public void deleteMember(Long id) {
         final Member member = findMemberById(id);
         member.softDelete();
         log.info("Member deleted: {}", member);
-        return MemberMapper.INSTANCE.toDto(member);
     }
 
     @Transactional

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postitsolve/entity/PostitSolve.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postitsolve/entity/PostitSolve.java
@@ -1,14 +1,20 @@
-package org.programmers.signalbuddyfinal.domain.postitSolve.entity;
+package org.programmers.signalbuddyfinal.domain.postitsolve.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.programmers.signalbuddyfinal.domain.basetime.BaseTimeEntity;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.postit.entity.Postit;
-
-import java.time.LocalDateTime;
 
 @Entity(name = "postits_solves")
 @Getter

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathController.java
@@ -1,0 +1,27 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
+import org.programmers.signalbuddyfinal.domain.recentpath.service.RecentPathService;
+import org.programmers.signalbuddyfinal.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/recent-path")
+@RequiredArgsConstructor
+public class RecentPathController {
+
+    private final RecentPathService recentPathService;
+
+    @PatchMapping("{id}")
+    public ResponseEntity<ApiResponse<RecentPathResponse>> updateRecentPathTime(
+        @PathVariable Long id) {
+        final RecentPathResponse response = recentPathService.updateRecentPathTime(id);
+        return ResponseEntity.ok(ApiResponse.createSuccess(response));
+    }
+
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathController.java
@@ -5,6 +5,7 @@ import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse
 import org.programmers.signalbuddyfinal.domain.recentpath.service.RecentPathService;
 import org.programmers.signalbuddyfinal.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,4 +25,9 @@ public class RecentPathController {
         return ResponseEntity.ok(ApiResponse.createSuccess(response));
     }
 
+    @DeleteMapping("{id}/bookmarks")
+    public ResponseEntity<ApiResponse<Object>> unlinkBookmark(@PathVariable Long id) {
+        recentPathService.unlinkBookmark(id);
+        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+    }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/dto/RecentPathRequest.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/dto/RecentPathRequest.java
@@ -1,0 +1,27 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class RecentPathRequest {
+    private String name;
+
+    @Min(value = -90, message = "위도는 -90 이상이어야 합니다.")
+    @Max(value = 90, message = "위도는 90 이하여야 합니다.")
+    private double lat;
+
+    @Min(value = -180, message = "경도는 -180 이상이어야 합니다.")
+    @Max(value = 180, message = "경도는 180 이하여야 합니다.")
+    private double lng;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/dto/RecentPathResponse.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/dto/RecentPathResponse.java
@@ -1,0 +1,29 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.dto;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@EqualsAndHashCode
+@Builder
+public class RecentPathResponse {
+
+    private Long recentPathId;
+
+    private String name;
+
+    private double lng;
+
+    private double lat;
+
+    private LocalDateTime lastAccessedAt;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/dto/RecentPathResponse.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/dto/RecentPathResponse.java
@@ -25,5 +25,7 @@ public class RecentPathResponse {
 
     private double lat;
 
+    private boolean isBookmarked;
+
     private LocalDateTime lastAccessedAt;
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/entity/RecentPath.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/entity/RecentPath.java
@@ -1,5 +1,6 @@
 package org.programmers.signalbuddyfinal.domain.recentpath.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -49,6 +50,7 @@ public class RecentPath extends BaseTimeEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bookmark_id", nullable = true)
+    @JsonIgnore
     private Bookmark bookmark;
 
     @Builder
@@ -65,5 +67,9 @@ public class RecentPath extends BaseTimeEntity {
 
     public void updateLastAccessedTime() {
         this.lastAccessedAt = LocalDateTime.now();
+    }
+
+    public void unlinkBookmark() {
+        this.bookmark = null;
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/entity/RecentPath.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/entity/RecentPath.java
@@ -1,6 +1,13 @@
-package org.programmers.signalbuddyfinal.domain.recentPath.entity;
+package org.programmers.signalbuddyfinal.domain.recentpath.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,11 +33,11 @@ public class RecentPath extends BaseTimeEntity {
     private Point endPoint;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id",nullable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bookmark_id",nullable = false)
+    @JoinColumn(name = "bookmark_id", nullable = false)
     private Bookmark bookmark;
 
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/entity/RecentPath.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/entity/RecentPath.java
@@ -8,9 +8,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.locationtech.jts.geom.Point;
 import org.programmers.signalbuddyfinal.domain.basetime.BaseTimeEntity;
 import org.programmers.signalbuddyfinal.domain.bookmark.entity.Bookmark;
@@ -20,6 +26,8 @@ import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 @Entity(name = "recent_paths")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
 public class RecentPath extends BaseTimeEntity {
 
     @Id
@@ -32,12 +40,30 @@ public class RecentPath extends BaseTimeEntity {
     @Column(nullable = false)
     private Point endPoint;
 
+    @Column(nullable = false)
+    private LocalDateTime lastAccessedAt; // 최근 방문 시간
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bookmark_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bookmark_id", nullable = true)
     private Bookmark bookmark;
 
+    @Builder
+    public RecentPath(String name, Point endPoint, Member member) {
+        this.name = name;
+        this.endPoint = endPoint;
+        this.member = member;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.lastAccessedAt = LocalDateTime.now();
+    }
+
+    public void updateLastAccessedTime() {
+        this.lastAccessedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/entity/RecentPath.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/entity/RecentPath.java
@@ -72,4 +72,8 @@ public class RecentPath extends BaseTimeEntity {
     public void unlinkBookmark() {
         this.bookmark = null;
     }
+
+    public void linkBookmark(Bookmark bookmark) {
+        this.bookmark = bookmark;
+    }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/exception/RecentPathErrorCode.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/exception/RecentPathErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum RecentPathErrorCode implements ErrorCode {
 
-    NOT_FOUND_RECENT_PATH(HttpStatus.NOT_FOUND, "10000", "해당 경로가 존재하지 않습니다.");
+    NOT_FOUND_RECENT_PATH(HttpStatus.NOT_FOUND, "10000", "해당 경로가 존재하지 않습니다."),
+    INVALID_COORDINATES(HttpStatus.BAD_REQUEST, "10001", "위도 또는 경도 값이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/mapper/RecentPathMapper.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/mapper/RecentPathMapper.java
@@ -19,6 +19,7 @@ public interface RecentPathMapper {
 
     @Mapping(target = "lng", expression = "java(getLng(recentPath.getEndPoint()))")
     @Mapping(target = "lat", expression = "java(getLat(recentPath.getEndPoint()))")
+    @Mapping(target = "isBookmarked", expression = "java(isBookmarked(recentPath))")
     RecentPathResponse toDto(RecentPath recentPath);
 
     default double getLng(Point point) {
@@ -27,5 +28,9 @@ public interface RecentPathMapper {
 
     default double getLat(Point point) {
         return point.getY();
+    }
+
+    default boolean isBookmarked(RecentPath recentPath) {
+        return recentPath.getBookmark() != null; // Bookmark가 존재하면 true
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/mapper/RecentPathMapper.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/mapper/RecentPathMapper.java
@@ -1,0 +1,31 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.mapper;
+
+import org.locationtech.jts.geom.Point;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathRequest;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
+import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
+
+@Mapper
+public interface RecentPathMapper {
+
+    RecentPathMapper INSTANCE = Mappers.getMapper(RecentPathMapper.class);
+
+    @Mapping(source = "point", target = "endPoint")
+    RecentPath toEntity(RecentPathRequest request, Point point, Member member);
+
+    @Mapping(target = "lng", expression = "java(getLng(recentPath.getEndPoint()))")
+    @Mapping(target = "lat", expression = "java(getLat(recentPath.getEndPoint()))")
+    RecentPathResponse toDto(RecentPath recentPath);
+
+    default double getLng(Point point) {
+        return point.getX();
+    }
+
+    default double getLat(Point point) {
+        return point.getY();
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/repository/RecentPathRepository.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/repository/RecentPathRepository.java
@@ -1,10 +1,14 @@
 package org.programmers.signalbuddyfinal.domain.recentpath.repository;
 
+import java.util.List;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecentPathRepository extends JpaRepository<RecentPath, Long> {
 
+    List<RecentPath> findAllByMemberOrderByLastAccessedAtDesc(Member member, Limit limit);
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/repository/RecentPathRepository.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/repository/RecentPathRepository.java
@@ -1,0 +1,10 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.repository;
+
+import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecentPathRepository extends JpaRepository<RecentPath, Long> {
+
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
@@ -63,4 +63,12 @@ public class RecentPathService {
         recentPath.updateLastAccessedTime();
         return RecentPathMapper.INSTANCE.toDto(recentPath);
     }
+
+    @Transactional
+    public void unlinkBookmark(Long id) {
+        final RecentPath recentPath = recentPathRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(RecentPathErrorCode.NOT_FOUND_RECENT_PATH));
+
+        recentPath.unlinkBookmark();
+    }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
@@ -1,5 +1,6 @@
 package org.programmers.signalbuddyfinal.domain.recentpath.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -14,6 +15,7 @@ import org.programmers.signalbuddyfinal.domain.recentpath.exception.RecentPathEr
 import org.programmers.signalbuddyfinal.domain.recentpath.mapper.RecentPathMapper;
 import org.programmers.signalbuddyfinal.domain.recentpath.repository.RecentPathRepository;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,5 +53,14 @@ public class RecentPathService {
             throw new BusinessException(RecentPathErrorCode.INVALID_COORDINATES);
         }
         return geometryFactory.createPoint(new Coordinate(lng, lat));
+    }
+
+    @Transactional
+    public RecentPathResponse updateRecentPathTime(Long id) {
+        final RecentPath recentPath = recentPathRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(RecentPathErrorCode.NOT_FOUND_RECENT_PATH));
+
+        recentPath.updateLastAccessedTime();
+        return RecentPathMapper.INSTANCE.toDto(recentPath);
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
@@ -36,6 +36,16 @@ public class RecentPathService {
         return RecentPathMapper.INSTANCE.toDto(save);
     }
 
+    @Transactional(readOnly = true)
+    public List<RecentPathResponse> getRecentPathList(Long memberId) {
+        final Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BusinessException(MemberErrorCode.NOT_FOUND_MEMBER));
+
+        final List<RecentPath> list = recentPathRepository.findAllByMemberOrderByLastAccessedAtDesc(
+            member, Limit.of(10));
+        return list.stream().map(RecentPathMapper.INSTANCE::toDto).toList();
+    }
+
     private Point toPoint(double lng, double lat) {
         if (lng < -180 || lng > 180 || lat < -90 || lat > 90) {
             throw new BusinessException(RecentPathErrorCode.INVALID_COORDINATES);

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
@@ -1,0 +1,45 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.service;
+
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+import org.programmers.signalbuddyfinal.domain.member.exception.MemberErrorCode;
+import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathRequest;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
+import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
+import org.programmers.signalbuddyfinal.domain.recentpath.exception.RecentPathErrorCode;
+import org.programmers.signalbuddyfinal.domain.recentpath.mapper.RecentPathMapper;
+import org.programmers.signalbuddyfinal.domain.recentpath.repository.RecentPathRepository;
+import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RecentPathService {
+
+    private final RecentPathRepository recentPathRepository;
+    private final MemberRepository memberRepository;
+    private final GeometryFactory geometryFactory;
+
+    @Transactional
+    public RecentPathResponse saveRecentPath(Long memberId, RecentPathRequest request) {
+        final Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BusinessException(MemberErrorCode.NOT_FOUND_MEMBER));
+
+        final Point point = toPoint(request.getLng(), request.getLat());
+        final RecentPath recentPath = RecentPathMapper.INSTANCE.toEntity(request, point, member);
+        final RecentPath save = recentPathRepository.save(recentPath);
+        return RecentPathMapper.INSTANCE.toDto(save);
+    }
+
+    private Point toPoint(double lng, double lat) {
+        if (lng < -180 || lng > 180 || lat < -90 || lat > 90) {
+            throw new BusinessException(RecentPathErrorCode.INVALID_COORDINATES);
+        }
+        return geometryFactory.createPoint(new Coordinate(lng, lat));
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/trafficsignal/entity/TrafficSignal.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/trafficsignal/entity/TrafficSignal.java
@@ -1,6 +1,10 @@
-package org.programmers.signalbuddyfinal.domain.trafficSignal.entity;
+package org.programmers.signalbuddyfinal.domain.trafficsignal.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepositoryTest.java
@@ -83,7 +83,7 @@ class BookmarkRepositoryTest extends RepositoryTest {
     @Test
     void getBookmarkBySequences() {
         final List<Integer> sequences = List.of(1, 3, 5, 9);
-        final List<Bookmark> bookmarks = bookmarkRepository.findAllBySequenceIn(sequences);
+        final List<Bookmark> bookmarks = bookmarkRepository.findAllBySequenceInAndMemberMemberId(sequences, member.getMemberId());
 
         assertThat(bookmarks).isNotEmpty().allSatisfy(bookmark -> {
             assertThat(bookmark.getMember()).isEqualTo(member);

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/bookmark/repository/BookmarkRepositoryTest.java
@@ -1,5 +1,8 @@
 package org.programmers.signalbuddyfinal.domain.bookmark.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +21,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 class BookmarkRepositoryTest extends RepositoryTest {
 
     private final GeometryFactory geometryFactory = new GeometryFactory();
@@ -33,22 +34,23 @@ class BookmarkRepositoryTest extends RepositoryTest {
     @BeforeEach
     void setUp() {
         member = Member.builder().email("test@example.com").password("password123")
-            .nickname("TestUser").profileImageUrl("http://example.com/profile.jpg").role(MemberRole.USER)
-            .memberStatus(MemberStatus.ACTIVITY).build();
+            .nickname("TestUser").profileImageUrl("http://example.com/profile.jpg")
+            .role(MemberRole.USER).memberStatus(MemberStatus.ACTIVITY).build();
+        member = memberRepository.save(member);
+
+        Point point = geometryFactory.createPoint(new Coordinate(127.12345, 37.12345));
+
+        for (int i = 1; i <= 10; i++) {
+            Bookmark bookmark = Bookmark.builder().address("Address " + i).coordinate(point)
+                .member(member).build();
+            bookmark.updateSequence(i);
+            bookmarkRepository.save(bookmark);
+        }
     }
 
     @DisplayName("즐겨찾기 목록 조회 테스트")
     @Test
     void testGetBookmarksWithPagination() {
-        Member member1 = memberRepository.save(member);
-        Point point = geometryFactory.createPoint(new Coordinate(127.12345, 37.12345));
-
-        for (int i = 1; i <= 10; i++) {
-            Bookmark bookmark = Bookmark.builder().address("Address " + i).coordinate(point)
-                .member(member1).build();
-            bookmarkRepository.save(bookmark);
-        }
-
         /* H2 데이터베이스에서 ST_X 함수 이용 X*/
         Pageable pageable = PageRequest.of(0, 5);
         Page<BookmarkResponse> bookmarksPage = bookmarkRepository.findPagedByMember(pageable, 1L);
@@ -65,4 +67,26 @@ class BookmarkRepositoryTest extends RepositoryTest {
 
     }
 
+    @DisplayName("북마크 아이디 리스트와 멤버 아이디 조건으로 조회")
+    @Test
+    void getBookmarkByIdsAndMemberId() {
+        final List<Long> ids = List.of(1L, 2L, 3L, 4L);
+        final List<Bookmark> bookmarks = bookmarkRepository.findAllByBookmarkIdInAndMemberMemberId(
+            ids, member.getMemberId());
+
+        assertThat(bookmarks).isNotEmpty().allSatisfy(bookmark -> {
+            assertThat(bookmark.getMember()).isEqualTo(member);
+        });
+    }
+
+    @DisplayName("시퀀스 목록으로 북마크 리스트 조회")
+    @Test
+    void getBookmarkBySequences() {
+        final List<Integer> sequences = List.of(1, 3, 5, 9);
+        final List<Bookmark> bookmarks = bookmarkRepository.findAllBySequenceIn(sequences);
+
+        assertThat(bookmarks).isNotEmpty().allSatisfy(bookmark -> {
+            assertThat(bookmark.getMember()).isEqualTo(member);
+        });
+    }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
@@ -8,6 +8,7 @@ import static com.epages.restdocs.apispec.Schema.schema;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.commonResponse;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.commonResponseFormat;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.pageResponseFormat;
@@ -32,7 +33,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkRequest;
 import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkResponse;
+import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkSequenceUpdateRequest;
 import org.programmers.signalbuddyfinal.domain.bookmark.service.BookmarkService;
 import org.programmers.signalbuddyfinal.domain.feedback.dto.FeedbackResponse;
 import org.programmers.signalbuddyfinal.domain.feedback.entity.enums.AnswerStatus;
@@ -220,11 +223,9 @@ class MemberControllerTest extends ControllerTest {
     @Test
     void deleteMember() throws Exception {
         final Long memberId = 1L;
-        final MemberResponse memberResponse = MemberResponse.builder().memberId(memberId)
-            .memberStatus(MemberStatus.WITHDRAWAL).role(MemberRole.USER).email("test@example.com")
-            .nickname("Test").build();
 
-        given(memberService.deleteMember(memberId)).willReturn(memberResponse);
+        doNothing().when(memberService).deleteMember(memberId);
+
         ResultActions result = mockMvc.perform(delete("/api/members/{id}", memberId));
 
         result.andExpect(status().isOk()).andDo(
@@ -232,20 +233,7 @@ class MemberControllerTest extends ControllerTest {
                 resource(ResourceSnippetParameters.builder().tag(tag).summary("유저 탈퇴")
                     .pathParameters(
                         parameterWithName("id").type(SimpleType.NUMBER).description("유저 ID"))
-                    .responseSchema(schema("MemberResponse")).responseFields(
-                        ArrayUtils.addAll(commonResponseFormat(),
-                            fieldWithPath("data.memberId").type(JsonFieldType.NUMBER)
-                                .description("유저 ID"),
-                            fieldWithPath("data.email").type(JsonFieldType.STRING)
-                                .description("유저 이메일"),
-                            fieldWithPath("data.nickname").type(JsonFieldType.STRING)
-                                .description("유저 닉네임"),
-                            fieldWithPath("data.profileImageUrl").type(JsonFieldType.STRING)
-                                .optional().description("프로필 이미지 URL"),
-                            fieldWithPath("data.role").type(JsonFieldType.STRING)
-                                .description("유저 역할"),
-                            fieldWithPath("data.memberStatus").type(JsonFieldType.STRING)
-                                .description("유저 상태"))).build())));
+                    .build())));
     }
 
     @DisplayName("비밀번호 확인")
@@ -366,6 +354,193 @@ class MemberControllerTest extends ControllerTest {
                                 fieldWithPath("data.searchResults[].address").type(JsonFieldType.STRING)
                                     .description("주소"),
                                 fieldWithPath("data.searchResults[].name").type(JsonFieldType.STRING)
-                                    .description("별칭 (예: 우리집, 회사)"))).build())));
+                                    .description("별칭 (예: 우리집, 회사)"),
+                                fieldWithPath("data.searchResults[].sequence").type(
+                                    JsonFieldType.NUMBER).description("순서"))).build())));
+    }
+
+    @DisplayName("나의 장소 상세 조회")
+    @Test
+    void getBookmark() throws Exception {
+        final Long memberId = 1L;
+        final Long bookmarkId = 1L;
+        final BookmarkResponse response = BookmarkResponse.builder().bookmarkId(1L).lat(37.501)
+            .lng(127.001).address("서울특별시 강남구 테헤란로 123").name("강남역").build();
+
+        given(bookmarkService.getBookmark(memberId, bookmarkId)).willReturn(response);
+
+        final ResultActions result = mockMvc.perform(
+            get("/api/members/{id}/bookmarks/{bookmarkId}", memberId, bookmarkId));
+
+        result.andExpect(status().isOk()).andDo(
+            document("나의 장소 상세 조회", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), resource(
+                    ResourceSnippetParameters.builder().tag(tag).summary("나의 장소 상세 조회")
+                        .pathParameters(
+                            parameterWithName("id").type(SimpleType.NUMBER).description("유저 ID"),
+                            parameterWithName("bookmarkId").type(SimpleType.NUMBER)
+                                .description("북마크 ID")).responseSchema(schema("BookmarkResponse"))
+                        .responseFields(ArrayUtils.addAll(commonResponseFormat(),
+                            fieldWithPath("data.bookmarkId").type(JsonFieldType.NUMBER)
+                                .description("북마크 ID"),
+                            fieldWithPath("data.lat").type(JsonFieldType.NUMBER).description("위도"),
+                            fieldWithPath("data.lng").type(JsonFieldType.NUMBER).description("경도"),
+                            fieldWithPath("data.address").type(JsonFieldType.STRING)
+                                .description("주소"),
+                            fieldWithPath("data.name").type(JsonFieldType.STRING).description("별칭"),
+                            fieldWithPath("data.sequence").type(JsonFieldType.NUMBER)
+                                .description("조회 순서"))).build())));
+    }
+
+    @DisplayName("나의 장소 저장")
+    @Test
+    void saveBookmark() throws Exception {
+        final Long memberId = 1L;
+
+        final BookmarkRequest request = BookmarkRequest.builder().lat(37.501).lng(127.001)
+            .address("서울특별시 강남구 테헤란로 123").name("강남역").build();
+
+        final BookmarkResponse response = BookmarkResponse.builder().bookmarkId(1L).lat(37.501)
+            .lng(127.001).address("서울특별시 강남구 테헤란로 123").name("강남역").sequence(1).build();
+
+        given(bookmarkService.createBookmark(any(BookmarkRequest.class), eq(memberId))).willReturn(
+            response);
+
+        final ResultActions result = mockMvc.perform(
+            post("/api/members/{id}/bookmarks", memberId).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isCreated()).andDo(
+            document("나의 장소 저장", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), resource(
+                    ResourceSnippetParameters.builder().tag(tag).summary("나의 장소 저장").pathParameters(
+                            parameterWithName("id").type(SimpleType.NUMBER).description("유저 ID"))
+                        .requestSchema(schema("BookmarkCreateRequest")).requestFields(
+                            fieldWithPath("lat").type(JsonFieldType.NUMBER).description("위도"),
+                            fieldWithPath("lng").type(JsonFieldType.NUMBER).description("경도"),
+                            fieldWithPath("address").type(JsonFieldType.STRING).description("주소"),
+                            fieldWithPath("name").type(JsonFieldType.STRING).description("이름"))
+                        .responseSchema(schema("BookmarkResponse")).responseFields(
+                            ArrayUtils.addAll(commonResponseFormat(),
+                                fieldWithPath("data.bookmarkId").type(JsonFieldType.NUMBER)
+                                    .description("북마크 ID"),
+                                fieldWithPath("data.lat").type(JsonFieldType.NUMBER).description("위도"),
+                                fieldWithPath("data.lng").type(JsonFieldType.NUMBER).description("경도"),
+                                fieldWithPath("data.address").type(JsonFieldType.STRING)
+                                    .description("주소"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING).description("별칭"),
+                                fieldWithPath("data.sequence").type(JsonFieldType.NUMBER)
+                                    .description("조회 순서"))).build())));
+    }
+
+    @DisplayName("나의 장소 수정")
+    @Test
+    void updateBookmark() throws Exception {
+        final Long memberId = 1L;
+        final Long bookmarkId = 1L;
+
+        final BookmarkRequest request = BookmarkRequest.builder().lat(37.501).lng(127.001)
+            .address("수정된 주소").name("수정된 별칭").build();
+
+        final BookmarkResponse response = BookmarkResponse.builder().bookmarkId(1L).lat(37.501)
+            .lng(127.001).address("수정된 주소").name("수정된 별칭").sequence(1).build();
+
+        given(bookmarkService.updateBookmark(any(BookmarkRequest.class), eq(bookmarkId),
+            eq(memberId))).willReturn(response);
+
+        final ResultActions result = mockMvc.perform(
+            patch("/api/members/{id}/bookmarks/{bookmarkId}", memberId, bookmarkId).contentType(
+                MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isOk()).andDo(
+            document("나의 장소 수정", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), resource(
+                    ResourceSnippetParameters.builder().tag(tag).summary("나의 장소 수정").pathParameters(
+                            parameterWithName("id").type(SimpleType.NUMBER).description("유저 ID"),
+                            parameterWithName("bookmarkId").type(SimpleType.NUMBER)
+                                .description("북마크 ID")).requestSchema(schema("BookmarkUpdateRequest"))
+                        .requestFields(
+                            fieldWithPath("lat").type(JsonFieldType.NUMBER).description("위도"),
+                            fieldWithPath("lng").type(JsonFieldType.NUMBER).description("경도"),
+                            fieldWithPath("address").type(JsonFieldType.STRING).description("주소"),
+                            fieldWithPath("name").type(JsonFieldType.STRING).description("이름"))
+                        .responseSchema(schema("BookmarkResponse")).responseFields(
+                            ArrayUtils.addAll(commonResponseFormat(),
+                                fieldWithPath("data.bookmarkId").type(JsonFieldType.NUMBER)
+                                    .description("북마크 ID"),
+                                fieldWithPath("data.lat").type(JsonFieldType.NUMBER).description("위도"),
+                                fieldWithPath("data.lng").type(JsonFieldType.NUMBER).description("경도"),
+                                fieldWithPath("data.address").type(JsonFieldType.STRING)
+                                    .description("주소"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING).description("별칭"),
+                                fieldWithPath("data.sequence").type(JsonFieldType.NUMBER)
+                                    .description("조회 순서"))).build())));
+    }
+
+    @DisplayName("나의 장소 삭제")
+    @Test
+    void deleteBookmark() throws Exception {
+        final Long memberId = 1L;
+        final List<Long> bookmarkIds = List.of(1L, 2L, 3L);
+
+        doNothing().when(bookmarkService).deleteBookmark(bookmarkIds, memberId);
+
+        final ResultActions result = mockMvc.perform(
+            delete("/api/members/{id}/bookmarks", memberId).param("bookmarkIds",
+                bookmarkIds.stream().map(String::valueOf).toArray(String[]::new)));
+        // DELETE /bookmarks?bookmarkIds=1,2,3
+
+        result.andExpect(status().isOk()).andDo(
+            document("나의 장소 삭제", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), resource(
+                    ResourceSnippetParameters.builder().tag(tag)
+                        .summary("나의 장소 삭제")
+                        .pathParameters(
+                            parameterWithName("id").type(SimpleType.NUMBER).description("유저 ID"))
+                        .formParameters(parameterWithName("bookmarkIds").type(SimpleType.NUMBER)
+                            .description("삭제할 북마크 ID 배열 (예: /api/members/1/bookmarks?bookmarkIds=1,2,3)")).build())));
+    }
+
+    @DisplayName("나의 장소 순서 변경")
+    @Test
+    void updateBookmarkSequence() throws Exception {
+        final Long memberId = 1L;
+        final List<BookmarkSequenceUpdateRequest> requests = List.of(
+            new BookmarkSequenceUpdateRequest(1L, 3), new BookmarkSequenceUpdateRequest(2L, 5),
+            new BookmarkSequenceUpdateRequest(3L, 9));
+
+        final List<BookmarkResponse> responses = List.of(
+            BookmarkResponse.builder().bookmarkId(1L).lat(37.501).lng(127.001).address("수정된 주소1")
+                .name("수정된 별칭1").sequence(3).build(),
+            BookmarkResponse.builder().bookmarkId(2L).lat(37.501).lng(127.001).address("수정된 주소2")
+                .name("수정된 별칭2").sequence(5).build(),
+            BookmarkResponse.builder().bookmarkId(3L).lat(37.501).lng(127.001).address("수정된 주소3")
+                .name("수정된 별칭3").sequence(9).build());
+
+        given(bookmarkService.updateBookmarkSequences(memberId, requests)).willReturn(responses);
+        final ResultActions result = mockMvc.perform(
+            patch("/api/members/{id}/bookmarks/sequence/reorder", memberId).contentType(
+                MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requests)));
+
+        result.andExpect(status().isOk()).andDo(
+            document("나의 장소 순서 변경", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), resource(
+                    ResourceSnippetParameters.builder().tag(tag).summary("나의 장소 순서 변경")
+                        .pathParameters(
+                            parameterWithName("id").type(SimpleType.NUMBER).description("유저 ID"))
+                        .responseSchema(schema("BookmarkResponseList")).responseFields(
+                            ArrayUtils.addAll(commonResponseFormat(),
+                                fieldWithPath("data[].bookmarkId").type(JsonFieldType.NUMBER)
+                                    .description("북마크 ID"),
+                                fieldWithPath("data[].lat").type(JsonFieldType.NUMBER)
+                                    .description("위도"),
+                                fieldWithPath("data[].lng").type(JsonFieldType.NUMBER)
+                                    .description("경도"),
+                                fieldWithPath("data[].address").type(JsonFieldType.STRING)
+                                    .description("주소"),
+                                fieldWithPath("data[].name").type(JsonFieldType.STRING)
+                                    .description("별칭"),
+                                fieldWithPath("data[].sequence").type(JsonFieldType.NUMBER)
+                                    .description("조회 순서"))).build())));
     }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
@@ -558,7 +558,7 @@ class MemberControllerTest extends ControllerTest {
             .name("Recent Path").build();
         final RecentPathResponse response = RecentPathResponse.builder().recentPathId(1L)
             .lat(37.501).lng(127.001).name("Recent Path").lastAccessedAt(LocalDateTime.now())
-            .build();
+            .isBookmarked(false).build();
 
         given(recentPathService.saveRecentPath(eq(memberId),
             any(RecentPathRequest.class))).willReturn(response);
@@ -585,7 +585,9 @@ class MemberControllerTest extends ControllerTest {
                                 fieldWithPath("data.name").type(JsonFieldType.STRING)
                                     .description("최근 경로 이름"),
                                 fieldWithPath("data.lastAccessedAt").type(JsonFieldType.STRING)
-                                    .description("최근 방문 시각"))).build())));
+                                    .description("최근 방문 시각"),
+                                fieldWithPath("data.bookmarked").type(JsonFieldType.BOOLEAN)
+                                    .description("나의 목적지와의 연관관계 여부"))).build())));
     }
 
     @DisplayName("최근 경로 목록 조회")
@@ -595,11 +597,11 @@ class MemberControllerTest extends ControllerTest {
 
         final List<RecentPathResponse> list = List.of(
             RecentPathResponse.builder().recentPathId(1L).lat(37.501).lng(127.001)
-                .name("Recent Path").lastAccessedAt(LocalDateTime.now()).build(),
+                .name("Recent Path").lastAccessedAt(LocalDateTime.now()).isBookmarked(false).build(),
             RecentPathResponse.builder().recentPathId(2L).lat(37.501).lng(127.001)
-                .name("Recent Path").lastAccessedAt(LocalDateTime.now()).build(),
+                .name("Recent Path").lastAccessedAt(LocalDateTime.now()).isBookmarked(false).build(),
             RecentPathResponse.builder().recentPathId(3L).lat(37.501).lng(127.001)
-                .name("Recent Path").lastAccessedAt(LocalDateTime.now()).build());
+                .name("Recent Path").lastAccessedAt(LocalDateTime.now()).isBookmarked(false).build());
 
         given(recentPathService.getRecentPathList(memberId)).willReturn(list);
 
@@ -623,6 +625,8 @@ class MemberControllerTest extends ControllerTest {
                                 fieldWithPath("data[].name").type(JsonFieldType.STRING)
                                     .description("최근 경로 이름"),
                                 fieldWithPath("data[].lastAccessedAt").type(JsonFieldType.STRING)
-                                    .description("최근 방문 시각"))).build())));
+                                    .description("최근 방문 시각"),
+                                fieldWithPath("data[].bookmarked").type(JsonFieldType.BOOLEAN)
+                                    .description("나의 목적지와의 연관관계 여부"))).build())));
     }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
@@ -587,4 +587,42 @@ class MemberControllerTest extends ControllerTest {
                                 fieldWithPath("data.lastAccessedAt").type(JsonFieldType.STRING)
                                     .description("최근 방문 시각"))).build())));
     }
+
+    @DisplayName("최근 경로 목록 조회")
+    @Test
+    void getRecentPathList() throws Exception {
+        final Long memberId = 1L;
+
+        final List<RecentPathResponse> list = List.of(
+            RecentPathResponse.builder().recentPathId(1L).lat(37.501).lng(127.001)
+                .name("Recent Path").lastAccessedAt(LocalDateTime.now()).build(),
+            RecentPathResponse.builder().recentPathId(2L).lat(37.501).lng(127.001)
+                .name("Recent Path").lastAccessedAt(LocalDateTime.now()).build(),
+            RecentPathResponse.builder().recentPathId(3L).lat(37.501).lng(127.001)
+                .name("Recent Path").lastAccessedAt(LocalDateTime.now()).build());
+
+        given(recentPathService.getRecentPathList(memberId)).willReturn(list);
+
+        final ResultActions result = mockMvc.perform(
+            get("/api/members/{id}/recent-path", memberId));
+
+        result.andExpect(status().isOk()).andDo(
+            document("최근 경로 목록 조회 (최대 10개)", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), resource(
+                    ResourceSnippetParameters.builder().tag(tag).summary("최근 경로 목록 조회 (최대 10개)")
+                        .pathParameters(
+                            parameterWithName("id").type(SimpleType.NUMBER).description("유저 ID"))
+                        .responseSchema(schema("RecentPathResponse")).responseFields(
+                            ArrayUtils.addAll(commonResponseFormat(),
+                                fieldWithPath("data[].recentPathId").type(JsonFieldType.NUMBER)
+                                    .description("최근 경로 ID"),
+                                fieldWithPath("data[].lat").type(JsonFieldType.NUMBER)
+                                    .description("위도"),
+                                fieldWithPath("data[].lng").type(JsonFieldType.NUMBER)
+                                    .description("경도"),
+                                fieldWithPath("data[].name").type(JsonFieldType.STRING)
+                                    .description("최근 경로 이름"),
+                                fieldWithPath("data[].lastAccessedAt").type(JsonFieldType.STRING)
+                                    .description("최근 방문 시각"))).build())));
+    }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
@@ -1,13 +1,12 @@
 package org.programmers.signalbuddyfinal.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,12 +24,6 @@ import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepositor
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockMultipartFile;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -74,12 +67,10 @@ class MemberServiceTest {
     @DisplayName("계정 수정 테스트")
     void updateMember() {
         final MemberUpdateRequest updateRequest = MemberUpdateRequest.builder()
-            .email("test2@example.com").nickname("TestUser2")
-            .password("password123").build();
+            .email("test2@example.com").nickname("TestUser2").password("password123").build();
 
         final MemberResponse expectedResponse = MemberResponse.builder().memberId(id)
-            .email("test2@example.com").nickname("TestUser2")
-            .memberStatus(MemberStatus.ACTIVITY)
+            .email("test2@example.com").nickname("TestUser2").memberStatus(MemberStatus.ACTIVITY)
             .role(MemberRole.USER).build();
 
         // MockHttpServletRequest와 MockHttpSession 생성

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
@@ -107,8 +107,8 @@ class MemberServiceTest {
         final MemberStatus expected = MemberStatus.WITHDRAWAL;
         when(memberRepository.findById(id)).thenReturn(Optional.of(member));
 
-        final MemberStatus actual = memberService.deleteMember(id).getMemberStatus();
-        assertThat(actual).isEqualTo(expected);
+        memberService.deleteMember(id);
+        assertThat(member.getMemberStatus()).isEqualTo(expected);
         verify(memberRepository, times(1)).findById(id);
     }
 

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathControllerTest.java
@@ -1,0 +1,70 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.Schema.schema;
+import static org.mockito.BDDMockito.given;
+import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.commonResponseFormat;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
+import org.programmers.signalbuddyfinal.domain.recentpath.service.RecentPathService;
+import org.programmers.signalbuddyfinal.global.support.ControllerTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
+
+@WebMvcTest(RecentPathController.class)
+class RecentPathControllerTest extends ControllerTest {
+
+    private final String tag = "RecentPath API";
+
+    @MockitoBean
+    private RecentPathService recentPathService;
+
+    @DisplayName("최근 경로 방문 시각 갱신")
+    @Test
+    void updateRecentPathTime() throws Exception {
+        final Long recentPathId = 1L;
+
+        final RecentPathResponse response = RecentPathResponse.builder().recentPathId(1L)
+            .lat(37.501).lng(127.001).name("Recent Path").lastAccessedAt(LocalDateTime.now())
+            .build();
+
+        given(recentPathService.updateRecentPathTime(recentPathId)).willReturn(response);
+
+        final ResultActions result = mockMvc.perform(patch("/api/recent-path/{id}", recentPathId));
+
+        result.andExpect(status().isOk()).andDo(
+            document("최근 경로 방문 시각 갱신", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), resource(
+                    ResourceSnippetParameters.builder().tag(tag).summary("최근 경로 방문 시각 갱신")
+                        .pathParameters(
+                            parameterWithName("id").type(SimpleType.NUMBER).description("최근 경로 ID"))
+                        .responseSchema(schema("RecentPathResponse")).responseFields(
+                            ArrayUtils.addAll(commonResponseFormat(),
+                                fieldWithPath("data.recentPathId").type(JsonFieldType.NUMBER)
+                                    .description("최근 경로 ID"),
+                                fieldWithPath("data.lat").type(JsonFieldType.NUMBER)
+                                    .description("위도"),
+                                fieldWithPath("data.lng").type(JsonFieldType.NUMBER)
+                                    .description("경도"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING)
+                                    .description("최근 경로 이름"),
+                                fieldWithPath("data.lastAccessedAt").type(JsonFieldType.STRING)
+                                    .description("최근 방문 시각"))).build())));
+    }
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathControllerTest.java
@@ -5,11 +5,13 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithNam
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.Schema.schema;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.commonResponseFormat;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -42,7 +44,7 @@ class RecentPathControllerTest extends ControllerTest {
 
         final RecentPathResponse response = RecentPathResponse.builder().recentPathId(1L)
             .lat(37.501).lng(127.001).name("Recent Path").lastAccessedAt(LocalDateTime.now())
-            .build();
+            .isBookmarked(false).build();
 
         given(recentPathService.updateRecentPathTime(recentPathId)).willReturn(response);
 
@@ -58,13 +60,32 @@ class RecentPathControllerTest extends ControllerTest {
                             ArrayUtils.addAll(commonResponseFormat(),
                                 fieldWithPath("data.recentPathId").type(JsonFieldType.NUMBER)
                                     .description("최근 경로 ID"),
-                                fieldWithPath("data.lat").type(JsonFieldType.NUMBER)
-                                    .description("위도"),
-                                fieldWithPath("data.lng").type(JsonFieldType.NUMBER)
-                                    .description("경도"),
+                                fieldWithPath("data.lat").type(JsonFieldType.NUMBER).description("위도"),
+                                fieldWithPath("data.lng").type(JsonFieldType.NUMBER).description("경도"),
                                 fieldWithPath("data.name").type(JsonFieldType.STRING)
                                     .description("최근 경로 이름"),
                                 fieldWithPath("data.lastAccessedAt").type(JsonFieldType.STRING)
-                                    .description("최근 방문 시각"))).build())));
+                                    .description("최근 방문 시각"),
+                                fieldWithPath("data.bookmarked").type(JsonFieldType.BOOLEAN)
+                                    .description("나의 목적지와의 연관관계 여부"))).build())));
+    }
+
+    @DisplayName("최근 경로와 북마크 연관 관계 제거")
+    @Test
+    void unlinkBookmark() throws Exception {
+        final Long recentPathId = 1L;
+
+        doNothing().when(recentPathService).unlinkBookmark(recentPathId);
+
+        final ResultActions result = mockMvc.perform(
+            delete("/api/recent-path/{id}/bookmarks", recentPathId));
+
+        result.andExpect(status().isOk()).andDo(
+            document("최근 경로와 북마크 연관 관계 제거", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), resource(
+                    ResourceSnippetParameters.builder().tag(tag).summary("최근 경로와 북마크 연관 관계 제거")
+                        .pathParameters(
+                            parameterWithName("id").type(SimpleType.NUMBER).description("최근 경로 ID"))
+                        .build())));
     }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/repository/RecentPathRepositoryTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/repository/RecentPathRepositoryTest.java
@@ -1,0 +1,58 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
+import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
+import org.programmers.signalbuddyfinal.global.support.RepositoryTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Limit;
+
+class RecentPathRepositoryTest extends RepositoryTest {
+
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    private Member member;
+
+    @Autowired
+    private RecentPathRepository recentPathRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder().email("test@example.com").password("password123")
+            .nickname("TestUser").profileImageUrl("http://example.com/profile.jpg")
+            .role(MemberRole.USER).memberStatus(MemberStatus.ACTIVITY).build();
+        member = memberRepository.save(member);
+
+        Point point = geometryFactory.createPoint(new Coordinate(127.12345, 37.12345));
+        for (int i = 1; i <= 15; i++) {
+            final RecentPath recentPath = RecentPath.builder().member(member).name("Recent Path")
+                .endPoint(point).build();
+            recentPathRepository.save(recentPath);
+        }
+    }
+
+    @DisplayName("최근 경로 목록 최대 10개 조회")
+    @Test
+    void getRecentPathsLimit10() {
+        final List<RecentPath> list = recentPathRepository.findAllByMemberOrderByLastAccessedAtDesc(
+            member, Limit.of(10));
+
+        assertThat(list).isNotEmpty().hasSize(10).allSatisfy(recentPath -> {
+            assertThat(recentPath.getMember()).isEqualTo(member);
+        });
+    }
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathServiceTest.java
@@ -1,0 +1,49 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
+import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathRequest;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
+import org.programmers.signalbuddyfinal.global.support.ServiceTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class RecentPathServiceTest extends ServiceTest {
+
+    @Autowired
+    private RecentPathService recentPathService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setup() {
+        member = Member.builder().email("bookmark@bookmark.com").password("123456")
+            .role(MemberRole.USER).nickname("bookmarkTest").memberStatus(MemberStatus.ACTIVITY)
+            .profileImageUrl("https://book-test-image.com/test-123131").build();
+        member = memberRepository.save(member);
+    }
+
+    @DisplayName("최근 경로 저장")
+    @Test
+    void saveRecentPath() {
+        final RecentPathRequest request = RecentPathRequest.builder()
+            .lat(37.12345).lng(127.12345).name("오징어집").build();
+
+        final RecentPathResponse response = recentPathService.saveRecentPath(member.getMemberId(),
+            request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getLastAccessedAt()).isNotNull();
+    }
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathServiceTest.java
@@ -1,19 +1,29 @@
 package org.programmers.signalbuddyfinal.domain.recentpath.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Point;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathRequest;
 import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
+import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
+import org.programmers.signalbuddyfinal.domain.recentpath.repository.RecentPathRepository;
 import org.programmers.signalbuddyfinal.global.support.ServiceTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -24,6 +34,9 @@ class RecentPathServiceTest extends ServiceTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @MockitoBean
+    private RecentPathRepository recentPathRepository;
 
     private Member member;
 
@@ -63,5 +76,30 @@ class RecentPathServiceTest extends ServiceTest {
         assertThat(recentPathList).isNotEmpty().allSatisfy(recentPathResponse -> {
             assertThat(recentPathResponse.getLastAccessedAt()).isNotNull();
         });
+    }
+
+    @DisplayName("최근 경로 방문 시간 갱신")
+    @Test
+    void updateRecentPathTime() {
+        LocalDateTime now = LocalDateTime.now().minusSeconds(1);;
+        final RecentPathResponse response = recentPathService.updateRecentPathTime(1L);
+        assertThat(response).isNotNull();
+        assertThat(response.getLastAccessedAt()).isNotNull();
+        assertThat(response.getLastAccessedAt()).isAfter(now);
+    }
+
+    @DisplayName("최근 경로와 북마크 연관관계 해제")
+    @Test
+    void unlinkBookmark() {
+        RecentPath realRecentPath = new RecentPath("테스트 경로", mock(Point.class), member);
+        RecentPath recentPath = spy(realRecentPath);
+        when(recentPathRepository.findById(1L)).thenReturn(Optional.of(recentPath));
+
+        // When
+        recentPathService.unlinkBookmark(1L);
+
+        // Then
+        verify(recentPath).unlinkBookmark();
+        assertThat(recentPath.getBookmark()).isNull();
     }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathServiceTest.java
@@ -2,6 +2,7 @@ package org.programmers.signalbuddyfinal.domain.recentpath.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,12 @@ class RecentPathServiceTest extends ServiceTest {
             .role(MemberRole.USER).nickname("bookmarkTest").memberStatus(MemberStatus.ACTIVITY)
             .profileImageUrl("https://book-test-image.com/test-123131").build();
         member = memberRepository.save(member);
+
+        for (int i = 1; i <= 10; i++) {
+            RecentPathRequest request = RecentPathRequest.builder()
+                .lat(37.12345).lng(127.12345).name("Name " + i).build();
+            recentPathService.saveRecentPath(member.getMemberId(), request);
+        }
     }
 
     @DisplayName("최근 경로 저장")
@@ -45,5 +52,16 @@ class RecentPathServiceTest extends ServiceTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getLastAccessedAt()).isNotNull();
+    }
+
+    @DisplayName("최근 경로 목록 조회")
+    @Test
+    void getRecentPathList() {
+        final List<RecentPathResponse> recentPathList = recentPathService.getRecentPathList(
+            member.getMemberId());
+
+        assertThat(recentPathList).isNotEmpty().allSatisfy(recentPathResponse -> {
+            assertThat(recentPathResponse.getLastAccessedAt()).isNotNull();
+        });
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #17 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 나의 장소 등록, 수정, 순서 변경, 조회 기능 구현
> 최근 경로 목록 조회 (최대 10개), 최근 경로 저장 구현
> 최근 경로를 북마크(나의 장소)에 등록하는 경우 기존 존재하는 북마크 저장 API 활용


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

