### PR TITLE
[Refactor] 최근경로 양방향 매핑 해제

### DIFF
--- a/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/bookmark/entity/Bookmark.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -20,7 +19,6 @@ import lombok.ToString;
 import org.locationtech.jts.geom.Point;
 import org.programmers.signalbuddyfinal.domain.basetime.BaseTimeEntity;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
-import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
 
 @Entity(name = "bookmarks")
 @Getter
@@ -52,9 +50,6 @@ public class Bookmark extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToOne(mappedBy = "bookmark")
-    private RecentPath recentPath;
-
     @Builder
     public Bookmark(Point coordinate, String address, Member member, String name) {
         this.coordinate = coordinate;
@@ -64,9 +59,6 @@ public class Bookmark extends BaseTimeEntity {
     }
 
     public void delete() {
-        if (this.recentPath != null) {
-            this.recentPath.unlinkBookmark(); // Bookmark 와의 연관관계 제거
-        }
         this.deletedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathController.java
@@ -1,6 +1,8 @@
 package org.programmers.signalbuddyfinal.domain.recentpath.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathLinkRequest;
 import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
 import org.programmers.signalbuddyfinal.domain.recentpath.service.RecentPathService;
 import org.programmers.signalbuddyfinal.global.response.ApiResponse;
@@ -8,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,5 +33,13 @@ public class RecentPathController {
     public ResponseEntity<ApiResponse<Object>> unlinkBookmark(@PathVariable Long id) {
         recentPathService.unlinkBookmark(id);
         return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+    }
+
+    @PostMapping("{id}/bookmarks")
+    public ResponseEntity<ApiResponse<RecentPathResponse>> addBookmark(@PathVariable Long id, @Valid @RequestBody
+        RecentPathLinkRequest recentPathLinkRequest) {
+        final RecentPathResponse response = recentPathService.linkBookmark(id,
+            recentPathLinkRequest);
+        return ResponseEntity.ok(ApiResponse.createSuccess(response));
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/dto/RecentPathLinkRequest.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/dto/RecentPathLinkRequest.java
@@ -1,0 +1,6 @@
+package org.programmers.signalbuddyfinal.domain.recentpath.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record RecentPathLinkRequest(@NotNull Long bookmarkId) {
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/repository/RecentPathRepository.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/repository/RecentPathRepository.java
@@ -1,6 +1,8 @@
 package org.programmers.signalbuddyfinal.domain.recentpath.repository;
 
+import java.util.Collection;
 import java.util.List;
+import org.programmers.signalbuddyfinal.domain.bookmark.entity.Bookmark;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
 import org.springframework.data.domain.Limit;
@@ -11,4 +13,6 @@ import org.springframework.stereotype.Repository;
 public interface RecentPathRepository extends JpaRepository<RecentPath, Long> {
 
     List<RecentPath> findAllByMemberOrderByLastAccessedAtDesc(Member member, Limit limit);
+
+    List<RecentPath> findAllByBookmarkIn(Collection<Bookmark> bookmarks);
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/recentpath/service/RecentPathService.java
@@ -5,9 +5,13 @@ import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.programmers.signalbuddyfinal.domain.bookmark.entity.Bookmark;
+import org.programmers.signalbuddyfinal.domain.bookmark.exception.BookmarkErrorCode;
+import org.programmers.signalbuddyfinal.domain.bookmark.repository.BookmarkRepository;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.exception.MemberErrorCode;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathLinkRequest;
 import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathRequest;
 import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
 import org.programmers.signalbuddyfinal.domain.recentpath.entity.RecentPath;
@@ -25,6 +29,7 @@ public class RecentPathService {
 
     private final RecentPathRepository recentPathRepository;
     private final MemberRepository memberRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final GeometryFactory geometryFactory;
 
     @Transactional
@@ -70,5 +75,18 @@ public class RecentPathService {
             .orElseThrow(() -> new BusinessException(RecentPathErrorCode.NOT_FOUND_RECENT_PATH));
 
         recentPath.unlinkBookmark();
+    }
+
+    @Transactional
+    public RecentPathResponse linkBookmark(Long id, RecentPathLinkRequest recentPathLinkRequest) {
+        final RecentPath recentPath = recentPathRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(RecentPathErrorCode.NOT_FOUND_RECENT_PATH));
+
+        final Long bookmarkId = recentPathLinkRequest.bookmarkId();
+        final Bookmark bookmark = bookmarkRepository.findById(bookmarkId)
+            .orElseThrow(() -> new BusinessException(BookmarkErrorCode.NOT_FOUND_BOOKMARK));
+
+        recentPath.linkBookmark(bookmark);
+        return RecentPathMapper.INSTANCE.toDto(recentPath);
     }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathControllerTest.java
@@ -6,6 +6,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.Schema.schema;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.commonResponseFormat;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -13,6 +14,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -20,10 +22,12 @@ import com.epages.restdocs.apispec.SimpleType;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathLinkRequest;
 import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
 import org.programmers.signalbuddyfinal.domain.recentpath.service.RecentPathService;
 import org.programmers.signalbuddyfinal.global.support.ControllerTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
@@ -87,5 +91,43 @@ class RecentPathControllerTest extends ControllerTest {
                         .pathParameters(
                             parameterWithName("id").type(SimpleType.NUMBER).description("최근 경로 ID"))
                         .build())));
+    }
+
+    @DisplayName("최근 경로와 북마크 연관 관계 생성")
+    @Test
+    void linkBookmark() throws Exception {
+        final Long recentPathId = 1L;
+
+        final RecentPathLinkRequest recentPathLinkRequest = new RecentPathLinkRequest(1L);
+        final RecentPathResponse response = RecentPathResponse.builder().recentPathId(recentPathId)
+            .lastAccessedAt(LocalDateTime.now()).isBookmarked(true).name("Recent Path").build();
+        when(recentPathService.linkBookmark(recentPathId, recentPathLinkRequest)).thenReturn(
+            response);
+
+        final ResultActions result = mockMvc.perform(
+            post("/api/recent-path/{id}/bookmarks", recentPathId).contentType(
+                    MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(recentPathLinkRequest)));
+
+        result.andExpect(status().isOk()).andDo(
+            document("최근 경로와 북마크 연관 관계 생성", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), resource(
+                    ResourceSnippetParameters.builder().tag(tag).summary("최근 경로와 북마크 연관 관계 생성")
+                        .pathParameters(
+                            parameterWithName("id").type(SimpleType.NUMBER).description("최근 경로 ID"))
+                        .requestSchema(schema("RecentPathLinkRequest")).requestFields(
+                            fieldWithPath("bookmarkId").type(JsonFieldType.NUMBER)
+                                .description("북마크 ID")).responseSchema(schema("RecentPathResponse"))
+                        .responseFields(ArrayUtils.addAll(commonResponseFormat(),
+                            fieldWithPath("data.recentPathId").type(JsonFieldType.NUMBER)
+                                .description("최근 경로 ID"),
+                            fieldWithPath("data.lat").type(JsonFieldType.NUMBER).description("위도"),
+                            fieldWithPath("data.lng").type(JsonFieldType.NUMBER).description("경도"),
+                            fieldWithPath("data.name").type(JsonFieldType.STRING)
+                                .description("최근 경로 이름"),
+                            fieldWithPath("data.lastAccessedAt").type(JsonFieldType.STRING)
+                                .description("최근 방문 시각"),
+                            fieldWithPath("data.bookmarked").type(JsonFieldType.BOOLEAN)
+                                .description("나의 목적지와의 연관관계 여부"))).build())));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #60 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> `Bookmark`와 `RecentPath` 양방향 매핑을 단방향으로 변경
> 최근경로에 북마크 연결 기능 추가


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

