### PR TITLE
[Refactor] S3 파일 업로드 반환 데이터 수정

### DIFF
--- a/src/main/java/org/programmers/signalbuddyfinal/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/feedback/service/FeedbackService.java
@@ -20,6 +20,7 @@ import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
 import org.programmers.signalbuddyfinal.global.dto.PageResponse;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
 import org.programmers.signalbuddyfinal.global.service.AwsFileService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +38,9 @@ public class FeedbackService {
     private final CrossroadRepository crossroadRepository;
     private final FeedbackReportRepository reportRepository;
     private final AwsFileService awsFileService;
+
+    @Value("${cloud.aws.s3.folder.feedback}")
+    private String feedbackDir;
 
     public PageResponse<FeedbackResponse> searchFeedbackList(
         Pageable pageable,
@@ -85,8 +89,8 @@ public class FeedbackService {
 
         String imageUrl = null;
         if (image != null) {
-            String fileName = awsFileService.saveProfileImage(image);
-            imageUrl = awsFileService.getProfileImage(fileName).toString();
+            String fileName = awsFileService.uploadFileToS3(image, feedbackDir);
+            imageUrl = awsFileService.getFileFromS3(fileName, feedbackDir).toString();
         }
 
         Feedback feedback = Feedback.create()
@@ -120,8 +124,8 @@ public class FeedbackService {
         }
 
         if (image != null) {
-            String fileName = awsFileService.saveProfileImage(image);
-            String imageUrl = awsFileService.getProfileImage(fileName).toString();
+            String fileName = awsFileService.uploadFileToS3(image, feedbackDir);
+            String imageUrl = awsFileService.getFileFromS3(fileName, feedbackDir).toString();
             feedback.updateImageUrl(imageUrl);
         }
 

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
@@ -82,19 +82,6 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.createSuccess(verified));
     }
 
-    /**
-     * ApiResponse 는 JSON 형태의 응답을 생성하는데 사용되므로 <br> 이미지 파일을 직접 반환하기 위해
-     * {@code ResponseEntity<Resource>}를 사용.
-     *
-     * @param id Member ID
-     * @return Resource 객체
-     */
-    @GetMapping("{id}/profile-image")
-    public ResponseEntity<Resource> getImageFile(@PathVariable Long id) {
-        final Resource profileImage = memberService.getProfileImage(id);
-        return ResponseEntity.ok(profileImage);
-    }
-
     @GetMapping("{id}/feedbacks")
     public ResponseEntity<ApiResponse<PageResponse<FeedbackResponse>>> getFeedbacks(
         @PathVariable Long id, @PageableDefault(page = 0, size = 10) Pageable pageable) {

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/exception/MemberErrorCode.java
@@ -12,12 +12,8 @@ public enum MemberErrorCode implements ErrorCode {
 
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "06000", "해당 사용자를 찾을 수 없습니다."),
     ALREADY_EXIST_EMAIL(HttpStatus.CONFLICT, "06001", "이미 존재하는 이메일 입니다."),
-    PROFILE_IMAGE_LOAD_ERROR_NOT_EXIST_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "06002", "유효하지 않은 URL 또는 읽을 수 없는 파일입니다."),
-    WITHDRAWN_MEMBER(HttpStatus.FORBIDDEN, "06003", "탈퇴한 회원입니다."),
-    PROFILE_IMAGE_UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "06004", "프로필 이미지 저장 중 오류가 발생했습니다."),
-    PROFILE_IMAGE_LOAD_ERROR_INVALID_URL(HttpStatus.INTERNAL_SERVER_ERROR, "06005", "URL 생성 중 오류가 발생했습니다."),
-    S3_UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "06006", "S3 업로드 중 오류가 발생했습니다."),
-    ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, "06007", "이미 존재하는 닉네임 입니다.");
+    WITHDRAWN_MEMBER(HttpStatus.FORBIDDEN, "06002", "탈퇴한 회원입니다."),
+    ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, "06003", "이미 존재하는 닉네임 입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/service/MemberService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/service/MemberService.java
@@ -16,7 +16,6 @@ import org.programmers.signalbuddyfinal.global.exception.BusinessException;
 import org.programmers.signalbuddyfinal.global.security.basic.CustomUserDetails;
 import org.programmers.signalbuddyfinal.global.service.AwsFileService;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -96,7 +95,8 @@ public class MemberService {
             profileImageUrl = awsFileService.getFileFromS3(profilePath, memberDir).toString();
         } else {
             // 프로필 이미지를 저장하지 않았을 경우 기본 이미지
-            profileImageUrl = awsFileService.getFileFromS3(defaultProfileImage, memberDir).toString();
+            profileImageUrl = awsFileService.getFileFromS3(defaultProfileImage, memberDir)
+                .toString();
         }
 
         Member joinMember = Member.builder().email(memberJoinRequest.getEmail())

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/service/MemberService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/service/MemberService.java
@@ -17,7 +17,6 @@ import org.programmers.signalbuddyfinal.global.security.basic.CustomUserDetails;
 import org.programmers.signalbuddyfinal.global.service.AwsFileService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -37,7 +36,11 @@ public class MemberService {
     private BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
 
     @Value("${default.profile.image.path}")
-    private String defaultProfileImagePath;
+    private String defaultProfileImage;
+
+    @Value("${cloud.aws.s3.folder.member}")
+    private String memberDir;
+
 
     public MemberResponse getMember(Long id) {
         final Member member = memberRepository.findById(id)
@@ -66,7 +69,8 @@ public class MemberService {
     public String saveProfileImage(Long id, MultipartFile file) {
         final Member member = findMemberById(id);
         final String profileImage = saveProfileImageIfPresent(file);
-        member.saveProfileImage(profileImage);
+        final String imageUrl = awsFileService.getFileFromS3(profileImage, memberDir).toString();
+        member.saveProfileImage(imageUrl);
         return profileImage;
     }
 
@@ -82,34 +86,27 @@ public class MemberService {
 
         if (memberRepository.existsByEmail(memberJoinRequest.getEmail())) {
             throw new BusinessException(MemberErrorCode.ALREADY_EXIST_EMAIL);
-        }else if(memberRepository.existsByNickname(memberJoinRequest.getNickname())) {
+        } else if (memberRepository.existsByNickname(memberJoinRequest.getNickname())) {
             throw new BusinessException(MemberErrorCode.ALREADY_EXIST_NICKNAME);
         }
 
         String profilePath = saveProfileImageIfPresent(image);
+        String profileImageUrl = null;
+        if (profilePath != null) {
+            profileImageUrl = awsFileService.getFileFromS3(profilePath, memberDir).toString();
+        } else {
+            // 프로필 이미지를 저장하지 않았을 경우 기본 이미지
+            profileImageUrl = awsFileService.getFileFromS3(defaultProfileImage, memberDir).toString();
+        }
 
         Member joinMember = Member.builder().email(memberJoinRequest.getEmail())
             .nickname(memberJoinRequest.getNickname())
             .password(bCryptPasswordEncoder.encode(memberJoinRequest.getPassword()))
-            .profileImageUrl(profilePath).memberStatus(MemberStatus.ACTIVITY).role(MemberRole.USER)
-            .build();
+            .profileImageUrl(profileImageUrl).memberStatus(MemberStatus.ACTIVITY)
+            .role(MemberRole.USER).build();
 
         memberRepository.save(joinMember);
         return MemberMapper.INSTANCE.toDto(joinMember);
-    }
-
-    @Transactional(readOnly = true)
-    public Resource getProfileImage(Long id) {
-        final Member member = findMemberById(id);
-        final String profileImage = member.getProfileImageUrl();
-        try {
-            if (profileImage.isEmpty()) {
-                return new ClassPathResource(defaultProfileImagePath);
-            }
-            return awsFileService.getProfileImage(profileImage);
-        } catch (BusinessException e) {
-            return new ClassPathResource(defaultProfileImagePath);
-        }
     }
 
     public boolean verifyPassword(String password, Long id) {
@@ -127,7 +124,7 @@ public class MemberService {
         if (imageFile == null) {
             return null;
         }
-        return awsFileService.saveProfileImage(imageFile);
+        return awsFileService.uploadFileToS3(imageFile, memberDir);
     }
 
     private String encodedPassword(String password) {

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postit/service/PostItService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postit/service/PostItService.java
@@ -14,6 +14,7 @@ import org.programmers.signalbuddyfinal.domain.postit.repository.PostItRepositor
 import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
 import org.programmers.signalbuddyfinal.global.service.AwsFileService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,6 +28,9 @@ public class PostItService {
     private final PostItRepository postItRepository;
     private final MemberRepository memberRepository;
     private final AwsFileService awsFileService;
+
+    @Value("${cloud.aws.s3.folder.post-it}")
+    private String postItDir;
 
     @Transactional
     public PostItResponse createPostIt(PostItCreateRequest postItCreateRequest, MultipartFile image, CustomUser2Member user) {
@@ -77,8 +81,8 @@ public class PostItService {
     private String convertImageFile(MultipartFile image) {
         String imageUrl = null;
         if (image != null) {
-            String fileName = awsFileService.saveProfileImage(image);
-            imageUrl = awsFileService.getProfileImage(fileName).toString();
+            String fileName = awsFileService.uploadFileToS3(image, postItDir);
+            imageUrl = awsFileService.getFileFromS3(fileName, postItDir).toString();
         }
         return imageUrl;
     }

--- a/src/main/java/org/programmers/signalbuddyfinal/global/exception/GlobalErrorCode.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/global/exception/GlobalErrorCode.java
@@ -11,7 +11,11 @@ public enum GlobalErrorCode implements ErrorCode {
 
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "09000", "잘못된 요청입니다."),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "09001", "알 수 없는 에러가 발생했습니다. 관리자에게 문의하세요."),
-    ADMIN_ONLY(HttpStatus.FORBIDDEN, "09002", "접근할 권한이 없습니다.");
+    ADMIN_ONLY(HttpStatus.FORBIDDEN, "09002", "접근할 권한이 없습니다."),
+    FILE_LOAD_ERROR_NOT_EXIST_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "09003", "유효하지 않은 URL 또는 읽을 수 없는 파일입니다."),
+    FILE_UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "09004", "파일 저장 중 오류가 발생했습니다."),
+    FILE_LOAD_ERROR_INVALID_URL(HttpStatus.INTERNAL_SERVER_ERROR, "09005", "URL 생성 중 오류가 발생했습니다."),
+    S3_UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "09006", "S3 업로드 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/programmers/signalbuddyfinal/global/service/AwsFileService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/global/service/AwsFileService.java
@@ -1,52 +1,44 @@
 package org.programmers.signalbuddyfinal.global.service;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.programmers.signalbuddyfinal.domain.member.exception.MemberErrorCode;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.programmers.signalbuddyfinal.global.exception.GlobalErrorCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.UUID;
-
 @Service
 @RequiredArgsConstructor
-@Transactional
 @Slf4j
 public class AwsFileService {
 
     private final S3Client s3Client;
 
-    @Value("${cloud.aws.s3.folder.member}")
-    private String profileImageDir;
-
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    @Value("${default.profile.image.path}")
-    private String defaultProfileImagePath;
-
     /**
-     * S3에서 프로필 이미지를 가져옵니다.
+     * S3에서 파일을 가져옵니다.
      *
      * @param filename S3에 저장된 파일명
+     * @param dir      S3 저장 폴더
      * @return Resource 객체
      * @throws IllegalStateException 유효하지 않은 URL 또는 읽을 수 없는 파일인 경우
      */
-    public Resource getProfileImage(String filename) {
-        final String filePath = profileImageDir + filename;
+    public Resource getFileFromS3(String filename, String dir) {
+        final String filePath = dir + filename;
         final URL url = generateFileUrl(filePath);
 
         try {
@@ -54,33 +46,35 @@ public class AwsFileService {
 
             if (!resource.exists() || !resource.isReadable()) {
                 log.error("유효하지 않은 파일: {}", filePath);
-                throw new BusinessException(MemberErrorCode.PROFILE_IMAGE_LOAD_ERROR_NOT_EXIST_FILE);
+                throw new BusinessException(
+                    GlobalErrorCode.FILE_LOAD_ERROR_NOT_EXIST_FILE);
             }
 
             return resource;
         } catch (MalformedURLException e) {
             log.error("URL 생성 실패: {}", filePath, e);
-            throw new BusinessException(MemberErrorCode.PROFILE_IMAGE_LOAD_ERROR_INVALID_URL);
+            throw new BusinessException(GlobalErrorCode.FILE_LOAD_ERROR_INVALID_URL);
         }
     }
 
     /**
-     * S3에 프로필 이미지를 저장합니다.
+     * S3에 파일을 저장합니다.
      *
-     * @param profileImage 업로드할 프로필 이미지 파일
+     * @param file 업로드할 파일
+     * @param dir  S3 저장 폴더
      * @return 저장된 파일 이름
      * @throws IllegalStateException 파일 업로드 중 오류가 발생한 경우
      */
-    public String saveProfileImage(MultipartFile profileImage) {
-        final String uniqueFilename = UUID.randomUUID() + "-" + profileImage.getOriginalFilename();
-        final String key = profileImageDir + uniqueFilename;
+    public String uploadFileToS3(MultipartFile file, String dir) {
+        final String uniqueFilename = UUID.randomUUID() + "-" + file.getOriginalFilename();
+        final String key = dir + uniqueFilename;
 
-        try (InputStream inputStream = profileImage.getInputStream()) {
-            uploadToS3(key, inputStream, profileImage.getContentType(), profileImage.getSize());
+        try (InputStream inputStream = file.getInputStream()) {
+            uploadToS3(key, inputStream, file.getContentType(), file.getSize());
             return uniqueFilename;
         } catch (IOException e) {
-            log.error("파일 업로드 실패: {}", profileImage.getOriginalFilename(), e);
-            throw new BusinessException(MemberErrorCode.PROFILE_IMAGE_UPLOAD_FAILURE);
+            log.error("파일 업로드 실패: {}", file.getOriginalFilename(), e);
+            throw new BusinessException(GlobalErrorCode.FILE_UPLOAD_FAILURE);
         }
     }
 
@@ -112,7 +106,7 @@ public class AwsFileService {
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, size));
         } catch (Exception e) {
             log.error("파일 업로드 실패: {}", key, e);
-            throw new BusinessException(MemberErrorCode.S3_UPLOAD_FAILURE);
+            throw new BusinessException(GlobalErrorCode.S3_UPLOAD_FAILURE);
         }
     }
 

--- a/src/main/java/org/programmers/signalbuddyfinal/global/service/AwsFileService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/global/service/AwsFileService.java
@@ -2,7 +2,6 @@ package org.programmers.signalbuddyfinal.global.service;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -10,8 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
 import org.programmers.signalbuddyfinal.global.exception.GlobalErrorCode;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -30,31 +27,15 @@ public class AwsFileService {
     private String bucket;
 
     /**
-     * S3에서 파일을 가져옵니다.
+     * S3에 저장된 파일 URL 을 가져옵니다.
      *
      * @param filename S3에 저장된 파일명
      * @param dir      S3 저장 폴더
-     * @return Resource 객체
-     * @throws IllegalStateException 유효하지 않은 URL 또는 읽을 수 없는 파일인 경우
+     * @return URL 객체
      */
-    public Resource getFileFromS3(String filename, String dir) {
+    public URL getFileFromS3(String filename, String dir) {
         final String filePath = dir + filename;
-        final URL url = generateFileUrl(filePath);
-
-        try {
-            final UrlResource resource = createUrlResource(url);
-
-            if (!resource.exists() || !resource.isReadable()) {
-                log.error("유효하지 않은 파일: {}", filePath);
-                throw new BusinessException(
-                    GlobalErrorCode.FILE_LOAD_ERROR_NOT_EXIST_FILE);
-            }
-
-            return resource;
-        } catch (MalformedURLException e) {
-            log.error("URL 생성 실패: {}", filePath, e);
-            throw new BusinessException(GlobalErrorCode.FILE_LOAD_ERROR_INVALID_URL);
-        }
+        return generateFileUrl(filePath);
     }
 
     /**
@@ -110,14 +91,4 @@ public class AwsFileService {
         }
     }
 
-    /**
-     * UrlResource 생성 (테스트를 위한 메서드 분리)
-     *
-     * @param url 생성할 URL
-     * @return UrlResource 객체
-     * @throws MalformedURLException URL이 잘못된 경우.
-     */
-    protected UrlResource createUrlResource(URL url) throws MalformedURLException {
-        return new UrlResource(url);
-    }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/global/service/DefaultProfileImageInitializer.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/global/service/DefaultProfileImageInitializer.java
@@ -1,0 +1,83 @@
+package org.programmers.signalbuddyfinal.global.service;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DefaultProfileImageInitializer {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("classpath:static/images/member/profile-icon.png")
+    private Resource defaultImageResource;
+
+    @Value("${default.profile.image.path}")
+    private String key;
+
+    @Value("${cloud.aws.s3.folder.member}")
+    private String memberDir;
+
+    /**
+     * 서버 초기화 후 기본 프로필 이미지의 존재 여부를 확인하고, 존재하지 않을 경우 로컬 리소스에서 이미지를 S3에 업로드.
+     */
+    @PostConstruct
+    public void initDefaultProfileImage() {
+        if (!isImageExistInS3()) {
+            log.info("기본 프로필 이미지가 S3에 존재하지 않습니다. 업로드를 시작합니다.");
+            uploadDefaultImageToS3();
+        } else {
+            log.info("기본 프로필 이미지가 이미 S3에 존재합니다.");
+        }
+    }
+
+
+    /**
+     * S3에 키를 가진 객체가 존재하는지 확인합니다.
+     *
+     * @return 객체가 존재하면 true, 그렇지 않으면 false
+     */
+    private boolean isImageExistInS3() {
+        try {
+            s3Client.headObject(
+                HeadObjectRequest.builder().bucket(bucket).key(memberDir + key).build());
+            return true;
+        } catch (S3Exception e) {
+            log.warn("S3에서 기본 프로필 이미지 조회 실패: {}", e.awsErrorDetails().errorMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 로컬 리소스에 있는 기본 이미지를 S3에 업로드.
+     */
+    private void uploadDefaultImageToS3() {
+        try (InputStream is = defaultImageResource.getInputStream()) {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(bucket)
+                .key(memberDir + key).contentType("image/png").build();
+
+            s3Client.putObject(putObjectRequest,
+                RequestBody.fromInputStream(is, defaultImageResource.contentLength()));
+            log.info("기본 프로필 이미지를 S3에 업로드하였습니다.");
+        } catch (IOException e) {
+            log.error("로컬 기본 이미지 로딩 실패", e);
+        } catch (S3Exception e) {
+            log.error("S3 업로드 실패: {}", e.awsErrorDetails().errorMessage(), e);
+        }
+    }
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback/service/FeedbackServiceTest.java
@@ -85,9 +85,9 @@ class FeedbackServiceTest extends ServiceTest {
 
         // When
         Resource mockResource = mock(UrlResource.class);
-        when(awsFileService.saveProfileImage(any(MockMultipartFile.class)))
+        when(awsFileService.uploadFileToS3(any(MockMultipartFile.class), anyString()))
             .thenReturn(imageFile.getName());
-        when(awsFileService.getProfileImage(anyString())).thenReturn(mockResource);
+        when(awsFileService.getFileFromS3(anyString(), anyString())).thenReturn(mockResource);
         FeedbackResponse actual = feedbackService.writeFeedback(request, imageFile, user);
 
         // Then
@@ -227,9 +227,9 @@ class FeedbackServiceTest extends ServiceTest {
 
         // When
         Resource mockResource = mock(UrlResource.class);
-        when(awsFileService.saveProfileImage(any(MockMultipartFile.class)))
+        when(awsFileService.uploadFileToS3(any(MockMultipartFile.class), anyString()))
             .thenReturn(updatedImageFile.getName());
-        when(awsFileService.getProfileImage(anyString())).thenReturn(mockResource);
+        when(awsFileService.getFileFromS3(anyString(), anyString())).thenReturn(mockResource);
         FeedbackResponse actual = feedbackService.updateFeedback(
             feedbackId, request, updatedImageFile, user
         );

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback/service/FeedbackServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.getMockImageFile;
 
+import java.net.URL;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -84,10 +85,10 @@ class FeedbackServiceTest extends ServiceTest {
         CustomUser2Member user = getCurrentMember(member.getMemberId(), MemberRole.USER);
 
         // When
-        Resource mockResource = mock(UrlResource.class);
+        URL mockURL = mock(URL.class);
         when(awsFileService.uploadFileToS3(any(MockMultipartFile.class), anyString()))
             .thenReturn(imageFile.getName());
-        when(awsFileService.getFileFromS3(anyString(), anyString())).thenReturn(mockResource);
+        when(awsFileService.getFileFromS3(anyString(), anyString())).thenReturn(mockURL);
         FeedbackResponse actual = feedbackService.writeFeedback(request, imageFile, user);
 
         // Then
@@ -226,10 +227,10 @@ class FeedbackServiceTest extends ServiceTest {
         CustomUser2Member user = getCurrentMember(member.getMemberId(), MemberRole.USER);
 
         // When
-        Resource mockResource = mock(UrlResource.class);
+        URL mockURL = mock(URL.class);
         when(awsFileService.uploadFileToS3(any(MockMultipartFile.class), anyString()))
             .thenReturn(updatedImageFile.getName());
-        when(awsFileService.getFileFromS3(anyString(), anyString())).thenReturn(mockResource);
+        when(awsFileService.getFileFromS3(anyString(), anyString())).thenReturn(mockURL);
         FeedbackResponse actual = feedbackService.updateFeedback(
             feedbackId, request, updatedImageFile, user
         );
@@ -239,7 +240,7 @@ class FeedbackServiceTest extends ServiceTest {
             softAssertions.assertThat(actual.getFeedbackId()).isEqualTo(feedbackId);
             softAssertions.assertThat(actual.getContent()).isEqualTo(updatedContent);
             softAssertions.assertThat(actual.getCategory()).isEqualTo(updatedCategory);
-            softAssertions.assertThat(actual.getImageUrl()).isEqualTo(mockResource.toString());
+            softAssertions.assertThat(actual.getImageUrl()).isEqualTo(mockURL.toString());
         });
     }
 

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
@@ -202,30 +202,6 @@ class MemberControllerTest extends ControllerTest {
                         .build())));
     }
 
-    @DisplayName("유저 프로필 이미지 조회")
-    @Test
-    void getProfileImage() throws Exception {
-        final Long memberId = 1L;
-
-        // 가상의 이미지 데이터를 가진 ByteArrayResource 생성
-        byte[] imageData = "dummy image data".getBytes();
-        Resource imageResource = new ByteArrayResource(imageData);
-
-        given(memberService.getProfileImage(memberId)).willReturn(imageResource);
-
-        ResultActions result = mockMvc.perform(get("/api/members/{id}/profile-image", memberId));
-
-        result.andExpect(status().isOk()).andDo(
-            document("유저 프로필 이미지 조회", preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()), resource(
-                    ResourceSnippetParameters.builder().tag(tag).summary("유저 프로필 이미지 조회")
-                        .pathParameters(
-                            parameterWithName("id").type(SimpleType.NUMBER).description("유저 ID"))
-                        .responseHeaders(
-                            headerWithName(HttpHeaders.CONTENT_TYPE).description("응답 콘텐츠 타입"))
-                        .build())));
-    }
-
     @DisplayName("유저 탈퇴")
     @Test
     void deleteMember() throws Exception {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
@@ -2,6 +2,8 @@ package org.programmers.signalbuddyfinal.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,6 +25,8 @@ import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.service.AwsFileService;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockMultipartFile;
@@ -112,14 +116,18 @@ class MemberServiceTest {
 
         MockMultipartFile profileImage = new MockMultipartFile("profileImage", "", "image/jpeg",
             new byte[0]);
-        ReflectionTestUtils.setField(memberService, "defaultProfileImagePath", "test-path");
+        ReflectionTestUtils.setField(memberService, "defaultProfileImage", "test-path");
+        ReflectionTestUtils.setField(memberService, "memberDir", "test-dir");
+
+        Resource mockResource = mock(UrlResource.class);
+        when(awsFileService.uploadFileToS3(any(MockMultipartFile.class), anyString())).thenReturn(profileImage.getName());
+        when(awsFileService.getFileFromS3(anyString(), anyString())).thenReturn(mockResource);
 
         //given
         final MemberJoinRequest request = MemberJoinRequest.builder().email("test2@example.com")
             .nickname("TestUser2").password("password123").build();
-        final String defaultProfileImageUrl = new ClassPathResource("test-path").toString();
         final Member expectedMember = Member.builder().memberId(id).email("test2@example.com")
-            .nickname("TestUser2").profileImageUrl(defaultProfileImageUrl).memberStatus(MemberStatus.ACTIVITY)
+            .nickname("TestUser2").profileImageUrl(mockResource.toString()).memberStatus(MemberStatus.ACTIVITY)
             .role(MemberRole.USER).build();
 
         when(memberRepository.save(any(Member.class))).thenReturn(expectedMember);

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
@@ -22,9 +22,11 @@ import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.service.AwsFileService;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -110,12 +112,14 @@ class MemberServiceTest {
 
         MockMultipartFile profileImage = new MockMultipartFile("profileImage", "", "image/jpeg",
             new byte[0]);
+        ReflectionTestUtils.setField(memberService, "defaultProfileImagePath", "test-path");
 
         //given
         final MemberJoinRequest request = MemberJoinRequest.builder().email("test2@example.com")
             .nickname("TestUser2").password("password123").build();
+        final String defaultProfileImageUrl = new ClassPathResource("test-path").toString();
         final Member expectedMember = Member.builder().memberId(id).email("test2@example.com")
-            .nickname("TestUser2").profileImageUrl(null).memberStatus(MemberStatus.ACTIVITY)
+            .nickname("TestUser2").profileImageUrl(defaultProfileImageUrl).memberStatus(MemberStatus.ACTIVITY)
             .role(MemberRole.USER).build();
 
         when(memberRepository.save(any(Member.class))).thenReturn(expectedMember);

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/service/MemberServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.URL;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -119,15 +120,15 @@ class MemberServiceTest {
         ReflectionTestUtils.setField(memberService, "defaultProfileImage", "test-path");
         ReflectionTestUtils.setField(memberService, "memberDir", "test-dir");
 
-        Resource mockResource = mock(UrlResource.class);
+        URL mockURL = mock(URL.class);
         when(awsFileService.uploadFileToS3(any(MockMultipartFile.class), anyString())).thenReturn(profileImage.getName());
-        when(awsFileService.getFileFromS3(anyString(), anyString())).thenReturn(mockResource);
+        when(awsFileService.getFileFromS3(anyString(), anyString())).thenReturn(mockURL);
 
         //given
         final MemberJoinRequest request = MemberJoinRequest.builder().email("test2@example.com")
             .nickname("TestUser2").password("password123").build();
         final Member expectedMember = Member.builder().memberId(id).email("test2@example.com")
-            .nickname("TestUser2").profileImageUrl(mockResource.toString()).memberStatus(MemberStatus.ACTIVITY)
+            .nickname("TestUser2").profileImageUrl(mockURL.toString()).memberStatus(MemberStatus.ACTIVITY)
             .role(MemberRole.USER).build();
 
         when(memberRepository.save(any(Member.class))).thenReturn(expectedMember);

--- a/src/test/java/org/programmers/signalbuddyfinal/global/service/AwsFileServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/global/service/AwsFileServiceTest.java
@@ -87,18 +87,12 @@ class AwsFileServiceTest {
         // bucket 과 profileImageDir에 값 넣기
         ReflectionTestUtils.setField(awsFileService, "bucket", bucketName);
 
-        // Spy AwsFileService, mock UrlResource 생성
+        // Spy AwsFileService
         AwsFileService spyService = spy(awsFileService);
-        UrlResource mockResource = mock(UrlResource.class);
-        when(mockResource.exists()).thenReturn(true);
-        when(mockResource.isReadable()).thenReturn(true);
-        doReturn(mockResource).when(spyService).createUrlResource(mockUrl);
 
-        Resource resource = spyService.getFileFromS3(fileName, dir);
+        URL resource = spyService.getFileFromS3(fileName, dir);
 
         assertNotNull(resource);
-        assertTrue(resource.exists());
-        assertTrue(resource.isReadable());
     }
 
     @Test

--- a/src/test/java/org/programmers/signalbuddyfinal/global/service/AwsFileServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/global/service/AwsFileServiceTest.java
@@ -1,13 +1,30 @@
 package org.programmers.signalbuddyfinal.global.service;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.programmers.signalbuddyfinal.domain.member.exception.MemberErrorCode;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.programmers.signalbuddyfinal.global.exception.GlobalErrorCode;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -17,16 +34,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AwsFileServiceTest {
@@ -41,6 +48,7 @@ class AwsFileServiceTest {
     @DisplayName("프로필 이미지 저장 성공 테스트")
     void saveProfileImage_Success() throws IOException {
         String fileName = "test-image.png";
+        String dir = "test-dir";
         MultipartFile mockFile = mock(MultipartFile.class);
         InputStream mockInputStream = new ByteArrayInputStream("dummy content".getBytes());
 
@@ -50,10 +58,10 @@ class AwsFileServiceTest {
         when(mockFile.getSize()).thenReturn((long) "dummy content".length());
 
         // Mock S3Client의 동작 설정
-        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-            .thenReturn(null); // putObject의 반환값을 지정
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(
+            null); // putObject의 반환값을 지정
 
-        String result = awsFileService.saveProfileImage(mockFile);
+        String result = awsFileService.uploadFileToS3(mockFile, dir);
 
         assertNotNull(result);
         assertTrue(result.contains(fileName));
@@ -66,6 +74,7 @@ class AwsFileServiceTest {
         String fileName = "test-image.png";
         String key = "profiles/" + fileName;
         String bucketName = "test-bucket";
+        String dir = "test-dir";
 
         // Mock S3Utilities
         S3Utilities mockUtilities = mock(S3Utilities.class);
@@ -77,7 +86,6 @@ class AwsFileServiceTest {
 
         // bucket 과 profileImageDir에 값 넣기
         ReflectionTestUtils.setField(awsFileService, "bucket", bucketName);
-        ReflectionTestUtils.setField(awsFileService, "profileImageDir", "profiles/");
 
         // Spy AwsFileService, mock UrlResource 생성
         AwsFileService spyService = spy(awsFileService);
@@ -86,7 +94,7 @@ class AwsFileServiceTest {
         when(mockResource.isReadable()).thenReturn(true);
         doReturn(mockResource).when(spyService).createUrlResource(mockUrl);
 
-        Resource resource = spyService.getProfileImage(fileName);
+        Resource resource = spyService.getFileFromS3(fileName, dir);
 
         assertNotNull(resource);
         assertTrue(resource.exists());
@@ -98,6 +106,7 @@ class AwsFileServiceTest {
     void saveProfileImage_Fail() throws IOException {
         // Given
         String fileName = "test-image.png";
+        String dir = "test-dir";
         MultipartFile mockFile = mock(MultipartFile.class);
         InputStream mockInputStream = new ByteArrayInputStream("dummy content".getBytes());
 
@@ -107,14 +116,14 @@ class AwsFileServiceTest {
         when(mockFile.getSize()).thenReturn((long) "dummy content".length());
 
         // S3Client가 예외를 던지도록 설정
-        doThrow(new RuntimeException("S3 upload failed"))
-            .when(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+        doThrow(new RuntimeException("S3 upload failed")).when(s3Client)
+            .putObject(any(PutObjectRequest.class), any(RequestBody.class));
 
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            awsFileService.saveProfileImage(mockFile);
+            awsFileService.uploadFileToS3(mockFile, dir);
         });
 
-        assertTrue(exception.getMessage().contains(MemberErrorCode.S3_UPLOAD_FAILURE.getMessage()));
+        assertTrue(exception.getMessage().contains(GlobalErrorCode.S3_UPLOAD_FAILURE.getMessage()));
 
     }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/global/service/DefaultProfileImageInitializerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/global/service/DefaultProfileImageInitializerTest.java
@@ -1,0 +1,77 @@
+package org.programmers.signalbuddyfinal.global.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultProfileImageInitializerTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    @Mock
+    private Resource defaultImageResource;
+
+    @InjectMocks
+    private DefaultProfileImageInitializer initializer;
+
+    @BeforeEach
+    public void setUp() {
+        ReflectionTestUtils.setField(initializer, "bucket", "test-bucket");
+        ReflectionTestUtils.setField(initializer, "defaultImageResource", defaultImageResource);
+        ReflectionTestUtils.setField(initializer, "key", "key");
+        ReflectionTestUtils.setField(initializer, "memberDir", "memberDir");
+    }
+
+    @DisplayName("S3에 기본 이미지가 존재하는 경우 업로드 실행되지 않아야 함")
+    @Test
+    public void initDefaultImageWhenImageExists() {
+        HeadObjectResponse dummyResponse = HeadObjectResponse.builder().build();
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(dummyResponse);
+
+        initializer.initDefaultProfileImage();
+
+        verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @DisplayName("S3에 기본 이미지가 존재하지 않으면 기본 이미지 업로드 실행")
+    @Test
+    public void initDefaultImageWhenImageNotExist() throws IOException {
+        // S3Exception을 발생시켜 S3에 이미지가 없음을 가정
+        S3Exception s3Exception = (S3Exception) S3Exception.builder().message("Not Found")
+            .awsErrorDetails(AwsErrorDetails.builder().errorMessage("Not Found").build()).build();
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenThrow(s3Exception);
+
+        byte[] dummyData = "dummy image data".getBytes();
+        InputStream dummyInputStream = new ByteArrayInputStream(dummyData);
+        when(defaultImageResource.getInputStream()).thenReturn(dummyInputStream);
+        when(defaultImageResource.contentLength()).thenReturn((long) dummyData.length);
+
+        initializer.initDefaultProfileImage();
+
+        verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+}


### PR DESCRIPTION
- 기본 프로필 이미지 S3 업로드 기능 추가
- 도메인별로 디렉토리 추가
- 멤버 프로필 이미지 반환 데이터 수정

## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #71 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> S3 반환 데이터 로직 통일 (S3 URL 리턴)
> 기본 프로필 이미지 S3 업로드 기능 추가


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->
![image](https://github.com/user-attachments/assets/2fbd2030-9ad2-470b-adbe-dc277fd8220c)



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 서버 로드 시 사용자 기본 프로필 이미지를 S3에 업로드되게 기능을 추가하였습니다.
> S3에 기본 프로필 이미지가 존재하지 않으면
```log
2025-02-26T15:05:08.368+09:00  INFO 16715 --- [signal-buddy-final] [           main] o.p.s.g.s.DefaultProfileImageInitializer : 기본 프로필 이미지가 S3에 존재하지 않습니다. 업로드를 시작합니다.
2025-02-26T15:05:08.438+09:00  INFO 16715 --- [signal-buddy-final] [           main] o.p.s.g.s.DefaultProfileImageInitializer : 기본 프로필 이미지를 S3에 업로드하였습니다.
```
> S3에 기본 프로필 이미지가 존재한다면
```log
2025-02-26T15:08:50.594+09:00  INFO 16885 --- [signal-buddy-final] [           main] o.p.s.g.s.DefaultProfileImageInitializer : 기본 프로필 이미지가 이미 S3에 존재합니다.
```
