### PR TITLE
[Feature] 포스트잇 해결 상태 변경 기능 구현

### DIFF
--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/service/MemberService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/service/MemberService.java
@@ -68,9 +68,8 @@ public class MemberService {
     public String saveProfileImage(Long id, MultipartFile file) {
         final Member member = findMemberById(id);
         final String profileImage = saveProfileImageIfPresent(file);
-        final String imageUrl = awsFileService.getFileFromS3(profileImage, memberDir).toString();
-        member.saveProfileImage(imageUrl);
-        return imageUrl;
+        member.saveProfileImage(profileImage);
+        return profileImage;
     }
 
     @Transactional

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postit/batch/JobConfig.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postit/batch/JobConfig.java
@@ -1,0 +1,72 @@
+package org.programmers.signalbuddyfinal.domain.postit.batch;
+
+import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddyfinal.domain.postit.entity.Postit;
+import org.programmers.signalbuddyfinal.domain.postit.service.PostItComplete;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration("postItJobConfig")
+@RequiredArgsConstructor
+@Slf4j
+public class JobConfig {
+
+    private static final int chunkSize = 10;
+    private final MemberRepository memberRepository;
+    private final EntityManagerFactory entityManagerFactory;
+    private final PostItComplete postItCompleteService;
+
+
+    @Bean
+    public Job completePostItJob(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager) {
+        return new JobBuilder("completePostItJob", jobRepository).incrementer(
+                new RunIdIncrementer())
+            .start(completePostItStep(jobRepository, transactionManager)).build();
+    }
+
+    @Bean
+    @JobScope
+    public Step completePostItStep(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager) {
+        return new StepBuilder("completePostItStep", jobRepository).<Postit, Postit>chunk(chunkSize,
+                transactionManager)
+            .allowStartIfComplete(true)
+            .reader(postItCustomReader()).writer(deletedAtWriter()).build();
+    }
+
+    @Bean
+    @StepScope
+    public PostItCustomReader postItCustomReader() {
+        return new PostItCustomReader(entityManagerFactory, chunkSize);
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<Postit> deletedAtWriter() {
+        LocalDateTime deletedAt = LocalDateTime.now();
+        return items -> {
+
+            if (items != null && !items.isEmpty()) {
+                items.forEach(postit -> {
+                    postItCompleteService.completePostIt(postit, deletedAt);
+                    }
+                );
+            }
+        };
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postit/batch/PostItCustomReader.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postit/batch/PostItCustomReader.java
@@ -1,0 +1,64 @@
+package org.programmers.signalbuddyfinal.domain.postit.batch;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddyfinal.domain.postit.entity.Postit;
+import org.programmers.signalbuddyfinal.domain.postit.entity.QPostit;
+import org.springframework.batch.item.ItemReader;
+
+@Slf4j
+public class PostItCustomReader implements ItemReader<Postit> {
+
+    private final JPAQueryFactory queryFactory;
+    private final int pageSize;
+    private Long lastSeenId;
+    private List<Postit> currentPage;
+    private int currentIndex;
+
+    public PostItCustomReader(EntityManagerFactory entityManagerFactory, int pageSize) {
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        this.queryFactory = new JPAQueryFactory(entityManager);
+        this.pageSize = pageSize;
+        this.lastSeenId = null;
+        this.currentIndex = 0;
+    }
+
+    @Override
+    public Postit read() {
+        if (currentPage == null || currentIndex >= currentPage.size()) {
+            fetchNextPage();
+        }
+
+        if (currentPage == null || currentPage.isEmpty()) {
+            return null;
+        }
+
+        Postit postit = currentPage.get(currentIndex);
+        currentIndex++;
+        return postit;
+    }
+
+    private void fetchNextPage() {
+        QPostit qPostit = QPostit.postit;
+
+        currentPage = queryFactory
+            .selectFrom(qPostit)
+            .where(
+                lastSeenId != null ? qPostit.postitId.gt(lastSeenId) : null,
+                qPostit.expiryDate.after(LocalDateTime.now())
+            ).orderBy(qPostit.postitId.asc())
+            .offset(0)
+            .limit(pageSize)
+            .fetch();
+
+        if (!currentPage.isEmpty()) {
+            lastSeenId = currentPage.get(currentPage.size() - 1).getPostitId();
+        }
+        currentIndex = 0;
+    }
+
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postit/batch/Scheduler.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postit/batch/Scheduler.java
@@ -1,0 +1,30 @@
+package org.programmers.signalbuddyfinal.domain.postit.batch;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration("postItScheduler")
+@RequiredArgsConstructor
+public class Scheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job completePostItJob;
+
+    @Scheduled(cron = "0 0 6,18 * * ?")
+    @SchedulerLock(
+        name = "DeleteMemberJobScheduler",
+        lockAtMostFor = "23h",
+        lockAtLeastFor = "23h")
+    public void runJob() throws Exception {
+
+        JobParameters params = new JobParametersBuilder()
+            .toJobParameters();
+        jobLauncher.run(completePostItJob, params);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,7 +33,8 @@ public class PostItController {
         @CurrentUser CustomUser2Member user
     ) {
         return ResponseEntity.ok(
-            ApiResponse.createSuccess(postItService.createPostIt(postItCreateRequest, image, user)));
+            ApiResponse.createSuccess(
+                postItService.createPostIt(postItCreateRequest, image, user)));
     }
 
     @PatchMapping("/{postitId}")
@@ -57,5 +57,14 @@ public class PostItController {
         postItService.deletePostIt(postitId, user);
         return ResponseEntity.ok(
             ApiResponse.createSuccessWithNoData());
+    }
+
+    @PatchMapping("/complete/{postitId}")
+    public ResponseEntity<ApiResponse<PostItResponse>> completePostIt(
+        @PathVariable(value = "postitId") Long postitId
+    ) {
+        return ResponseEntity.ok(
+            ApiResponse.createSuccess(
+                postItService.completePostIt(postitId)));
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postit/entity/Postit.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postit/entity/Postit.java
@@ -91,4 +91,11 @@ public class Postit extends BaseTimeEntity {
             this.imageUrl = imageUrl;
         }
     }
+
+    public void completePostIt(LocalDateTime deletedAt){
+        this.deletedAt = deletedAt;
+    }
+    public void returnPostIt(){
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postit/service/PostItComplete.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postit/service/PostItComplete.java
@@ -1,0 +1,37 @@
+package org.programmers.signalbuddyfinal.domain.postit.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddyfinal.domain.postit.entity.Postit;
+import org.programmers.signalbuddyfinal.domain.postitsolve.entity.PostitSolve;
+import org.programmers.signalbuddyfinal.domain.postitsolve.repository.PostitSolveRepository;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PostItComplete {
+
+    private final MemberRepository memberRepository;
+    private final PostitSolveRepository postitSolveRepository;
+
+    public void completePostIt(Postit postit, LocalDateTime deletedAt) {
+
+        postit.completePostIt(deletedAt);
+
+        Member member = memberRepository.findById(postit.getMember().getMemberId())
+            .orElse(null);
+
+        PostitSolve postitSolve = PostitSolve.creator()
+            .content(postit.getContent())
+            .deletedAt(deletedAt)
+            .imageUrl(postit.getImageUrl())
+            .member(member)
+            .postit(postit)
+            .build();
+
+        postitSolveRepository.save(postitSolve);
+    }
+}
+

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postit/service/PostItService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postit/service/PostItService.java
@@ -1,5 +1,6 @@
 package org.programmers.signalbuddyfinal.domain.postit.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.programmers.signalbuddyfinal.domain.crossroad.service.PointUtil;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
@@ -11,6 +12,7 @@ import org.programmers.signalbuddyfinal.domain.postit.entity.Postit;
 import org.programmers.signalbuddyfinal.domain.postit.exception.PostItErrorCode;
 import org.programmers.signalbuddyfinal.domain.postit.mapper.PostItMapper;
 import org.programmers.signalbuddyfinal.domain.postit.repository.PostItRepository;
+import org.programmers.signalbuddyfinal.domain.postitsolve.repository.PostitSolveRepository;
 import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
 import org.programmers.signalbuddyfinal.global.service.AwsFileService;
@@ -28,6 +30,8 @@ public class PostItService {
     private final PostItRepository postItRepository;
     private final MemberRepository memberRepository;
     private final AwsFileService awsFileService;
+    private final PostitSolveRepository postitSolveRepository;
+    private final PostItComplete postItComplete;
 
     @Value("${cloud.aws.s3.folder.post-it}")
     private String postItDir;
@@ -76,6 +80,17 @@ public class PostItService {
             throw new BusinessException(PostItErrorCode.POSTIT_MODIFIER_NOT_AUTHORIZED);
         }
         postit.delete();
+    }
+
+    @Transactional
+    public PostItResponse completePostIt(Long postitId) {
+
+        Postit postit = postItRepository.findByIdOrThrow(postitId);
+        LocalDateTime deletedAt = LocalDateTime.now();
+
+        postItComplete.completePostIt(postit,deletedAt);
+
+        return PostItMapper.INSTANCE.toResponse(postit);
     }
 
     private String convertImageFile(MultipartFile image) {

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postitsolve/entity/PostitSolve.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postitsolve/entity/PostitSolve.java
@@ -9,11 +9,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.programmers.signalbuddyfinal.domain.basetime.BaseTimeEntity;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+import org.programmers.signalbuddyfinal.domain.postit.entity.Danger;
 import org.programmers.signalbuddyfinal.domain.postit.entity.Postit;
 
 @Entity(name = "postits_solves")
@@ -49,4 +53,13 @@ public class PostitSolve extends BaseTimeEntity {
     public boolean isDeleted() {
         return deletedAt != null;
     } // 삭제 확인
+
+    @Builder(builderMethodName = "creator")
+    private PostitSolve(String content, String imageUrl, LocalDateTime deletedAt, Member member, Postit postit) {
+        this.content = Objects.requireNonNull(content);
+        this.imageUrl = Objects.requireNonNull(imageUrl);
+        this.deletedAt = Objects.requireNonNull(deletedAt);
+        this.member = Objects.requireNonNull(member);
+        this.postit = Objects.requireNonNull(postit);
+    }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/postitsolve/repository/PostitSolveRepository.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/postitsolve/repository/PostitSolveRepository.java
@@ -1,0 +1,10 @@
+package org.programmers.signalbuddyfinal.domain.postitsolve.repository;
+
+import org.programmers.signalbuddyfinal.domain.postitsolve.entity.PostitSolve;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostitSolveRepository extends JpaRepository<PostitSolve, Long> {
+
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItControllerTest.java
@@ -338,7 +338,7 @@ public class PostItControllerTest extends ControllerTest {
     @WithMockCustomUser
     public void deletePostIt() throws Exception {
 
-        CustomUserDetails customUserDetails = new CustomUserDetails(1L, "user1@gmamil.com", "1234",
+        CustomUserDetails customUserDetails = new CustomUserDetails(1L, "user1@gmamil.com", "12345",
             "url2.jpg", "user1", MemberRole.USER, MemberStatus.ACTIVITY);
         CustomUser2Member user = new CustomUser2Member(customUserDetails);
 

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItControllerTest.java
@@ -24,6 +24,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.requestP
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -366,6 +367,81 @@ public class PostItControllerTest extends ControllerTest {
                                     .description("삭제하려는 포스트잇 ID")
                             )
                             .build()
+                    )
+                )
+            );
+    }
+
+    @Test
+    @DisplayName("포스트잇 해결")
+    @WithMockCustomUser
+    public void completePostIt() throws Exception {
+        PostItResponse postItResponse = createResponse(1L);
+
+        given(postItService.completePostIt(anyLong())).willReturn(postItResponse);
+
+        final ResultActions result = mockMvc.perform(patch("/api/postits/complete/{postitId}",1L)
+                .with(csrf())
+                .header(HttpHeaders.AUTHORIZATION, getTokenExample())
+        );
+
+        result.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andDo(
+                document(
+                    "포스트잇 해결",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag(tag)
+                            .summary("포스트잇을 해결상태로 변경하는 API")
+                            .pathParameters(
+                                parameterWithName("postitId").type(SimpleType.NUMBER)
+                                    .description("해결하려는 포스트잇 ID")
+                            )
+                            .build()
+                    ),
+                    responseFields(
+                        ArrayUtils.addAll(
+                            commonResponseFormat(),
+                            fieldWithPath("data.postitId")
+                                .type(JsonFieldType.NUMBER)
+                                .description("생성된 포스트잇 ID"),
+                            fieldWithPath("data.danger")
+                                .type(JsonFieldType.STRING)
+                                .description("포스트잇 위험도"),
+                            fieldWithPath("data.lat")
+                                .type(JsonFieldType.NUMBER)
+                                .description("등록 위도"),
+                            fieldWithPath("data.lng")
+                                .type(JsonFieldType.NUMBER)
+                                .description("등록 경도"),
+                            fieldWithPath("data.subject")
+                                .type(JsonFieldType.STRING)
+                                .description("포스트잇 제목"),
+                            fieldWithPath("data.content")
+                                .type(JsonFieldType.STRING)
+                                .description("포스트잇 내용"),
+                            fieldWithPath("data.imageUrl")
+                                .type(JsonFieldType.STRING)
+                                .description("등록된 이미지 URL"),
+                            fieldWithPath("data.expiryDate")
+                                .type(JsonFieldType.STRING)
+                                .description("""
+                                    포스트잇 삭제 예정일
+                                    형식 : YYYY-MM-dd HH-mm
+                                    """),
+                            fieldWithPath("data.createDate")
+                                .type(JsonFieldType.STRING)
+                                .description("""
+                                    포스트잇 등록일
+                                    형식 : YYYY-MM-dd HH-mm
+                                    """),
+                            fieldWithPath("data.memberId")
+                                .type(JsonFieldType.NUMBER)
+                                .description("등록한 사용자 ID")
+                        )
                     )
                 )
             );

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/postit/service/PostItServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/postit/service/PostItServiceTest.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.programmers.signalbuddyfinal.domain.crossroad.service.PointUtil;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
@@ -21,6 +20,7 @@ import org.programmers.signalbuddyfinal.domain.postit.dto.PostItResponse;
 import org.programmers.signalbuddyfinal.domain.postit.entity.Danger;
 import org.programmers.signalbuddyfinal.domain.postit.entity.Postit;
 import org.programmers.signalbuddyfinal.domain.postit.repository.PostItRepository;
+import org.programmers.signalbuddyfinal.domain.postitsolve.repository.PostitSolveRepository;
 import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
 import org.programmers.signalbuddyfinal.global.security.basic.CustomUserDetails;
@@ -36,6 +36,8 @@ public class PostItServiceTest extends ServiceTest {
     private PostItService postItService;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private PostitSolveRepository postitSolveRepository;
 
     private Member member1;
     private Member member2;
@@ -150,6 +152,17 @@ public class PostItServiceTest extends ServiceTest {
             () -> postItService.deletePostIt(1L, user2));
     }
 
+
+    @Test
+    @DisplayName("포스트잇 해결 상태 변경 성공 테스트")
+    public void completePostItTest() {
+        postItRepository.save(
+            createPostIt(Danger.NOTICE, PointUtil.toPoint(1.0203, 1.3048), "제목1",
+                "제목1", "img1", LocalDateTime.of(2025, 1, 1, 0, 0), member1));
+
+        postItService.completePostIt(1L);
+        assertThat(postitSolveRepository.findById(1L).get().getDeletedAt()).isNotNull();
+    }
     private PostItRequest createPostItRequest(String subject, String content) {
 
         return PostItRequest.builder()


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #69 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 포스트잇 해결 상태 변경 기능 구현

해결 상태로 변경된 포스트잇은 deletedAt 값이 null -> LocalDateTime.now()로 변경 됩니다.

1. 사용자 변경
사용자는 포스트잇의 해결 상태를 변경할 수 있습니다.

2. 만료일이 지난 포스트잇 변경
배치와 스케줄러를 이용해 매일 6:00, 18:00시에 만료일이 지난 포스트잇 상태를 해결로 변경합니다. 


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 멘토링 결과 만료일을 서버에서 계속 추적할 필요 없다고 생각되어 상태 변경을 배치로 구현했습니다.
하루 두 번 조회하도록 했는데 주기에 대해서는 나중에 이야기 나눠보면 좋을 것 같습니다.