### PR TITLE
[Feature] FCM을 이용한 알림 전송

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ out/
 ### application*.yml ###
 src/main/resources/*.yml
 
+### firebase files ###
+src/main/resources/firebase/
+
 ### generated ###
 src/main/generated/
 

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,9 @@ dependencies {
 
     // MockWebServer
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+
+    // FireBase Admin SDK
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
 }
 
 // JaCoCo 버전 설정
@@ -207,12 +210,16 @@ tasks.named('test') {
     finalizedBy 'jacocoTestReport'
 }
 
-/* deploy 서브 모듈에 있는 config 파일들을 resources로 복사 */
-task copyYaml(type: Copy) {
+// 서브 모듈에 있는 config 파일들을 resources로 복사
+task copyConfig(type: Copy) {
     copy {
         from './submodule/config'
-        include '*.yml'
         into 'src/main/resources'
+    }
+    // firebase 관련 파일 복사
+    copy {
+        from './submodule/firebase'
+        into 'src/main/resources/firebase'
     }
 }
 

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/notification/controller/FcmController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/notification/controller/FcmController.java
@@ -1,0 +1,52 @@
+package org.programmers.signalbuddyfinal.domain.notification.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddyfinal.domain.notification.dto.FcmTokenRequest;
+import org.programmers.signalbuddyfinal.domain.notification.service.FcmService;
+import org.programmers.signalbuddyfinal.global.annotation.CurrentUser;
+import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
+import org.programmers.signalbuddyfinal.global.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/fcm")
+@RequiredArgsConstructor
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @PostMapping("/token")
+    public ResponseEntity<ApiResponse<Object>> registerToken(
+        @Valid @RequestBody FcmTokenRequest request,
+        @CurrentUser CustomUser2Member user
+    ) {
+        fcmService.registerToken(request.getDeviceToken(), user);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.createSuccessWithNoData());
+    }
+
+    @PatchMapping("/token")
+    public ResponseEntity<ApiResponse<Object>> updateToken(
+        @Valid @RequestBody FcmTokenRequest request,
+        @CurrentUser CustomUser2Member user
+    ) {
+        fcmService.updateToken(request.getDeviceToken(), user);
+        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+    }
+
+    @DeleteMapping("/token")
+    public ResponseEntity<ApiResponse<Object>> deleteToken(
+        @CurrentUser CustomUser2Member user
+    ) {
+        fcmService.deleteToken(user);
+        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/notification/dto/FcmMessage.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/notification/dto/FcmMessage.java
@@ -1,0 +1,19 @@
+package org.programmers.signalbuddyfinal.domain.notification.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FcmMessage {
+
+    private final String title;
+
+    private final String body;
+
+    @Builder
+    private FcmMessage(final String title, final String body) {
+        this.title = Objects.requireNonNull(title);
+        this.body = Objects.requireNonNull(body);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/notification/dto/FcmTokenRequest.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/notification/dto/FcmTokenRequest.java
@@ -1,0 +1,13 @@
+package org.programmers.signalbuddyfinal.domain.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FcmTokenRequest {
+
+    @NotBlank(message = "디바이스 토큰값은 비어있을 수 없습니다.")
+    private String deviceToken;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/notification/entity/FcmToken.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/notification/entity/FcmToken.java
@@ -1,0 +1,46 @@
+package org.programmers.signalbuddyfinal.domain.notification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.programmers.signalbuddyfinal.domain.basetime.BaseTimeEntity;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+
+@Getter
+@Entity(name = "fcm_tokens")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long fcmTokenId;
+
+    @Column(nullable = false)
+    private String deviceToken;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder(builderMethodName = "create")
+    private FcmToken(final String deviceToken, final Member member) {
+        this.deviceToken = Objects.requireNonNull(deviceToken);
+        this.member = Objects.requireNonNull(member);
+    }
+
+    public void updateDeviceToken(String deviceToken) {
+        if (!this.deviceToken.equals(deviceToken)) {
+            this.deviceToken = deviceToken;
+        }
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/notification/exception/FcmErrorCode.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/notification/exception/FcmErrorCode.java
@@ -1,0 +1,20 @@
+package org.programmers.signalbuddyfinal.domain.notification.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.programmers.signalbuddyfinal.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum FcmErrorCode implements ErrorCode {
+
+    FCM_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "19000", "FCM에 메시지 전송이 실패했습니다."),
+    FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "19001", "해당 FCM Token을 찾지 못했습니다."),
+    ALREADY_EXISTED_TOKEN(HttpStatus.CONFLICT, "19002", "이미 해당 사용자에 대한 FCM Token이 존재합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/notification/repository/FcmTokenRepository.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/notification/repository/FcmTokenRepository.java
@@ -1,0 +1,27 @@
+package org.programmers.signalbuddyfinal.domain.notification.repository;
+
+import java.util.Optional;
+import org.programmers.signalbuddyfinal.domain.notification.entity.FcmToken;
+import org.programmers.signalbuddyfinal.domain.notification.exception.FcmErrorCode;
+import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    @Query("SELECT ft FROM fcm_tokens ft WHERE ft.member.memberId = :memberId")
+    Optional<FcmToken> findByMemberId(@Param("memberId") Long memberId);
+
+    default FcmToken findByIdOrThrow(Long id) {
+        return findById(id)
+            .orElseThrow(() -> new BusinessException(FcmErrorCode.FCM_TOKEN_NOT_FOUND));
+    }
+
+    default FcmToken findByMemberIdOrThrow(Long memberId) {
+        return findByMemberId(memberId)
+            .orElseThrow(() -> new BusinessException(FcmErrorCode.FCM_TOKEN_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/notification/service/FcmService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/notification/service/FcmService.java
@@ -1,0 +1,79 @@
+package org.programmers.signalbuddyfinal.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddyfinal.domain.notification.dto.FcmMessage;
+import org.programmers.signalbuddyfinal.domain.notification.entity.FcmToken;
+import org.programmers.signalbuddyfinal.domain.notification.exception.FcmErrorCode;
+import org.programmers.signalbuddyfinal.domain.notification.repository.FcmTokenRepository;
+import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
+import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FcmService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final MemberRepository memberRepository;
+
+    @Async("customTaskExecutor")
+    public void sendMessage(FcmMessage request, CustomUser2Member user) {
+        FcmToken fcmToken = fcmTokenRepository.findByMemberIdOrThrow(user.getMemberId());
+
+        Notification notification = Notification.builder()
+            .setTitle(request.getTitle())
+            .setBody(request.getBody())
+            .build();
+
+        Message message = Message.builder()
+            .setToken(fcmToken.getDeviceToken())
+            .setNotification(notification)
+            .build();
+
+        try {
+            firebaseMessaging.send(message);
+        } catch (FirebaseMessagingException e) {
+            throw new BusinessException(FcmErrorCode.FCM_SEND_ERROR);
+        }
+    }
+
+    @Transactional
+    public void registerToken(String deviceToken, CustomUser2Member user) {
+        Optional<FcmToken> entity = fcmTokenRepository.findByMemberId(user.getMemberId());
+
+        if (entity.isPresent()) {
+            throw new BusinessException(FcmErrorCode.ALREADY_EXISTED_TOKEN);
+        }
+
+        Member member = memberRepository.findByIdOrThrow(user.getMemberId());
+
+        FcmToken fcmToken = FcmToken.create()
+            .deviceToken(deviceToken).member(member)
+            .build();
+
+        fcmTokenRepository.save(fcmToken);
+    }
+
+    @Transactional
+    public void updateToken(String deviceToken, CustomUser2Member user) {
+        FcmToken fcmToken = fcmTokenRepository.findByMemberIdOrThrow(user.getMemberId());
+        fcmToken.updateDeviceToken(deviceToken);
+    }
+
+    @Transactional
+    public void deleteToken(CustomUser2Member user) {
+        FcmToken fcmToken = fcmTokenRepository.findByMemberIdOrThrow(user.getMemberId());
+        fcmTokenRepository.delete(fcmToken);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/global/config/AsyncConfig.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/global/config/AsyncConfig.java
@@ -19,14 +19,16 @@ public class AsyncConfig implements AsyncConfigurer {
     }
 
     @Override
-    @Bean(name = "emailExecutor")
+    @Bean(name = "customTaskExecutor")
     public Executor getAsyncExecutor() {
+        int processors = Runtime.getRuntime().availableProcessors();
+
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(50);
-        executor.setQueueCapacity(20);
-        executor.setKeepAliveSeconds(30);
-        executor.setThreadNamePrefix("AsyncEmailExecutor-");
+        executor.setCorePoolSize(processors);
+        executor.setMaxPoolSize(processors * 2);
+        executor.setQueueCapacity(1000);
+        executor.setKeepAliveSeconds(60);
+        executor.setThreadNamePrefix("AsyncExecutor-");
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
 

--- a/src/main/java/org/programmers/signalbuddyfinal/global/config/FcmConfig.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/global/config/FcmConfig.java
@@ -1,0 +1,46 @@
+package org.programmers.signalbuddyfinal.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+public class FcmConfig {
+
+    @Value("${fcm.secret-path}")
+    private String secretKeyPath;
+
+    @Value("${fcm.project-id}")
+    private String projectId;
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        // 이미 FirebaseApp이 초기화되었는지 확인
+        List<FirebaseApp> firebaseApps = FirebaseApp.getApps();
+        if (!firebaseApps.isEmpty()) {
+            return firebaseApps.get(0); // 기존 앱 반환
+        }
+
+        ClassPathResource resource = new ClassPathResource(secretKeyPath);
+        InputStream secretKey = resource.getInputStream();
+
+        FirebaseOptions options = FirebaseOptions.builder()
+            .setCredentials(GoogleCredentials.fromStream(secretKey))
+            .setProjectId(projectId)
+            .build();
+        return FirebaseApp.initializeApp(options);
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        return FirebaseMessaging.getInstance(firebaseApp());
+    }
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/notification/controller/FcmControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/notification/controller/FcmControllerTest.java
@@ -1,0 +1,151 @@
+package org.programmers.signalbuddyfinal.domain.notification.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.getTokenExample;
+import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.jwtFormat;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddyfinal.domain.notification.dto.FcmTokenRequest;
+import org.programmers.signalbuddyfinal.domain.notification.service.FcmService;
+import org.programmers.signalbuddyfinal.global.anotation.WithMockCustomUser;
+import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
+import org.programmers.signalbuddyfinal.global.support.ControllerTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(FcmController.class)
+class FcmControllerTest extends ControllerTest {
+    
+    @MockitoBean
+    private FcmService fcmService;
+    
+    private String tag = "FCM Notification Controller";
+
+    @DisplayName("디바이스 토큰을 사용자와 매핑하여 저장한다.")
+    @Test
+    @WithMockCustomUser
+    void registerToken() throws Exception {
+        // Given
+        FcmTokenRequest request = new FcmTokenRequest("test token");
+        doNothing().when(fcmService).registerToken(anyString(), any(CustomUser2Member.class));
+        
+        // When
+        ResultActions result = mockMvc.perform(
+            post("/api/fcm/token")
+                .header(HttpHeaders.AUTHORIZATION, getTokenExample())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+        
+        result.andExpect(status().isCreated())
+            .andDo(
+                document(
+                    "디바이스 토큰 저장",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag(tag)
+                            .summary("디바이스 토큰 저장")
+                            .requestHeaders(
+                                jwtFormat()
+                            )
+                            .requestFields(
+                                fieldWithPath("deviceToken").type(JsonFieldType.STRING)
+                                    .description("FCM에서 받은 디바이스 토큰")
+                            )
+                            .build()
+                    )
+                )
+            );
+    }
+
+    @DisplayName("디바이스 토큰을 수정한다.")
+    @Test
+    @WithMockCustomUser
+    void updateToken() throws Exception {
+        // Given
+        FcmTokenRequest request = new FcmTokenRequest("test update token");
+        doNothing().when(fcmService).updateToken(anyString(), any(CustomUser2Member.class));
+
+        // When
+        ResultActions result = mockMvc.perform(
+            patch("/api/fcm/token")
+                .header(HttpHeaders.AUTHORIZATION, getTokenExample())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        result.andExpect(status().isOk())
+            .andDo(
+                document(
+                    "디바이스 토큰 수정",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag(tag)
+                            .summary("디바이스 토큰 수정")
+                            .requestHeaders(
+                                jwtFormat()
+                            )
+                            .requestFields(
+                                fieldWithPath("deviceToken").type(JsonFieldType.STRING)
+                                    .description("FCM에서 받은 새로운 디바이스 토큰")
+                            )
+                            .build()
+                    )
+                )
+            );
+    }
+
+    @DisplayName("해당 사용자의 디바이스 토큰을 삭제한다.")
+    @Test
+    @WithMockCustomUser
+    void deleteToken() throws Exception {
+        // Given
+        doNothing().when(fcmService).deleteToken(any(CustomUser2Member.class));
+
+        // When
+        ResultActions result = mockMvc.perform(
+            delete("/api/fcm/token")
+                .header(HttpHeaders.AUTHORIZATION, getTokenExample())
+        );
+
+        result.andExpect(status().isOk())
+            .andDo(
+                document(
+                    "디바이스 토큰 삭제",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag(tag)
+                            .summary("디바이스 토큰 삭제")
+                            .requestHeaders(
+                                jwtFormat()
+                            )
+                            .build()
+                    )
+                )
+            );
+    }
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/notification/service/FcmServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/notification/service/FcmServiceTest.java
@@ -1,0 +1,214 @@
+package org.programmers.signalbuddyfinal.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
+import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddyfinal.domain.notification.dto.FcmMessage;
+import org.programmers.signalbuddyfinal.domain.notification.entity.FcmToken;
+import org.programmers.signalbuddyfinal.domain.notification.exception.FcmErrorCode;
+import org.programmers.signalbuddyfinal.domain.notification.repository.FcmTokenRepository;
+import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
+import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.programmers.signalbuddyfinal.global.security.basic.CustomUserDetails;
+import org.programmers.signalbuddyfinal.global.support.ServiceTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class FcmServiceTest extends ServiceTest {
+
+    @Autowired
+    private FcmService fcmService;
+
+    @MockitoBean
+    private FirebaseMessaging firebaseMessaging;
+
+    @Autowired
+    private FcmTokenRepository fcmTokenRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = saveMember("test email", "tester");
+        saveFcmToken(member);
+    }
+
+    @DisplayName("알림 메시지를 보낸다.")
+    @Test
+    void sendMessage_Success() throws FirebaseMessagingException {
+        // Given
+        FcmMessage request = FcmMessage.builder()
+            .title("test title").body("test body")
+            .build();
+        CustomUser2Member user = getCurrentMember(member.getMemberId());
+
+        when(firebaseMessaging.send(any(Message.class))).thenReturn("mock_message_id");
+
+        // When
+        fcmService.sendMessage(request, user);
+
+        // Then
+        await()
+            .atMost(5, TimeUnit.SECONDS)
+            .untilAsserted(() ->
+                verify(firebaseMessaging, times(1)).send(any(Message.class))
+            );
+    }
+
+    @DisplayName("알림 메시지를 보내는 데 실패한다.")
+    @Test
+    void sendMessage_Failure()
+        throws FirebaseMessagingException {
+        // Given
+        FcmMessage request = FcmMessage.builder()
+            .title("test title").body("test body")
+            .build();
+        CustomUser2Member user = getCurrentMember(member.getMemberId());
+        Message message = Message.builder()
+            .setToken("test token")
+            .setNotification(Notification.builder()
+                .setTitle(request.getTitle())
+                .setBody(request.getBody())
+                .build())
+            .build();
+
+        when(firebaseMessaging.send(message))
+            .thenThrow(new BusinessException(FcmErrorCode.FCM_SEND_ERROR));
+
+        // When & Then
+        try {
+            fcmService.sendMessage(request, user);
+        } catch (BusinessException e) {
+            assertThat(e.getErrorCode()).isEqualTo(FcmErrorCode.FCM_SEND_ERROR);
+        }
+    }
+
+    @DisplayName("사용자가 디바이스 토큰을 처음 등록한다.")
+    @Test
+    void registerToken_Success() {
+        // Given
+        Member userMember = saveMember("test email2", "tester2");
+        String deviceToken = "test Token";
+        CustomUser2Member user = getCurrentMember(userMember.getMemberId());
+
+        // When
+        fcmService.registerToken(deviceToken, user);
+
+        // Then
+        FcmToken actual = fcmTokenRepository.findByMemberIdOrThrow(user.getMemberId());
+        assertThat(actual.getDeviceToken()).isEqualTo(deviceToken);
+    }
+
+    @DisplayName("디바이스 추가 등록 시 실패한다.")
+    @Test
+    void registerToken_Failure() {
+        // Given
+        Member userMember = saveMember("test email2", "tester2");
+        String deviceToken = "test Token";
+        CustomUser2Member user = getCurrentMember(userMember.getMemberId());
+
+        // When & Then
+        fcmService.registerToken(deviceToken, user);
+        try {
+            fcmService.registerToken(deviceToken, user);
+        } catch (BusinessException e) {
+            assertThat(e.getErrorCode()).isEqualTo(FcmErrorCode.ALREADY_EXISTED_TOKEN);
+        }
+    }
+
+    @DisplayName("사용자가 디바이스 토큰을 업데이트한다.")
+    @Test
+    void updateToken_Success() {
+        // Given
+        String updatedDeviceToken = "test updated Token";
+        CustomUser2Member user = getCurrentMember(member.getMemberId());
+
+        // When
+        fcmService.updateToken(updatedDeviceToken, user);
+
+        // Then
+        FcmToken actual = fcmTokenRepository.findByMemberIdOrThrow(user.getMemberId());
+        assertThat(actual.getDeviceToken()).isEqualTo(updatedDeviceToken);
+    }
+
+    @DisplayName("디바이스 토큰을 등록하지 않은 사용자가 토큰을 업데이트할 시 실패한다.")
+    @Test
+    void updateToken_Failure() {
+        // Given
+        Member userMember = saveMember("test email2", "tester2");
+        String updatedDeviceToken = "test updated Token";
+        CustomUser2Member user = getCurrentMember(userMember.getMemberId());
+
+        // When & Then
+        try {
+            fcmService.updateToken(updatedDeviceToken, user);
+        } catch (BusinessException e) {
+            assertThat(e.getErrorCode()).isEqualTo(FcmErrorCode.FCM_TOKEN_NOT_FOUND);
+        }
+    }
+
+    @DisplayName("사용자가 디바이스 토큰을 삭제한다.")
+    @Test
+    void deleteToken_Success() {
+        // Given
+        CustomUser2Member user = getCurrentMember(member.getMemberId());
+
+        // When
+        fcmService.deleteToken(user);
+
+        // Then
+        assertThat(fcmTokenRepository.findByMemberId(user.getMemberId())).isEmpty();
+    }
+
+    @DisplayName("본인 것이 아닌 토큰을 삭제할 시 실패한다.")
+    @Test
+    void deleteToken_Failure() {
+        // Given
+        Member userMember = saveMember("test email2", "tester2");
+        CustomUser2Member user = getCurrentMember(userMember.getMemberId());
+
+        // When & Then
+        try {
+            fcmService.deleteToken(user);
+        } catch (BusinessException e) {
+            assertThat(e.getErrorCode()).isEqualTo(FcmErrorCode.FCM_TOKEN_NOT_FOUND);
+        }
+    }
+
+    private Member saveMember(String email, String nickname) {
+        return memberRepository.save(
+            Member.builder().email(email).password("123456").role(MemberRole.USER)
+                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
+                .profileImageUrl("https://test-image.com/test-123131").build());
+    }
+
+    private FcmToken saveFcmToken(Member member) {
+        return fcmTokenRepository.save(
+            FcmToken.create().deviceToken("test token").member(member).build());
+    }
+
+    private CustomUser2Member getCurrentMember(Long id) {
+        return new CustomUser2Member(
+            new CustomUserDetails(id, "", "",
+                "", "", MemberRole.USER, MemberStatus.ACTIVITY));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #130 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> FCM이 발생한 디바이스 토큰을 등록, 수정, 삭제하는 API를 구현했습니다.
> FCM으로 알림을 전송하는 메서드를 구현했습니다. 


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> FCM 알림 메서드 테스트 Mocking 해서 진행했고, 실제 전송 테스트는 민혁님과 실제 데이터를 전송하면서 테스트를 완료했습니다.

