### PR TITLE
[Feature] 알림 계정별 알림 설정 유무

### DIFF
--- a/src/main/java/org/programmers/signalbuddyfinal/domain/comment/service/CommentService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/comment/service/CommentService.java
@@ -49,7 +49,9 @@ public class CommentService {
         commentRepository.save(comment);
 
         // 작성자 본인의 댓글은 알림 발송 안 함
-        if (Member.isNotSameMember(user, feedback.getMember())) {
+        if (Member.isNotSameMember(user, feedback.getMember()) &&
+            feedback.getMember().isNotificationEnabled()
+        ) {
             // 피드백 작성자에게 댓글 알림 발송
             FcmMessage message = makeCommentNotiMessage(user.getNickname(), feedback.getSubject());
             fcmService.sendMessage(message, feedback.getMember().getMemberId());

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.programmers.signalbuddyfinal.domain.bookmark.service.BookmarkService;
 import org.programmers.signalbuddyfinal.domain.feedback.dto.FeedbackResponse;
 import org.programmers.signalbuddyfinal.domain.feedback.service.FeedbackService;
 import org.programmers.signalbuddyfinal.domain.member.dto.MemberJoinRequest;
+import org.programmers.signalbuddyfinal.domain.member.dto.MemberNotiAllowRequest;
 import org.programmers.signalbuddyfinal.domain.member.dto.MemberResponse;
 import org.programmers.signalbuddyfinal.domain.member.dto.MemberRestoreRequest;
 import org.programmers.signalbuddyfinal.domain.member.dto.MemberUpdateRequest;
@@ -19,6 +20,8 @@ import org.programmers.signalbuddyfinal.domain.member.service.MemberService;
 import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathRequest;
 import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathResponse;
 import org.programmers.signalbuddyfinal.domain.recentpath.service.RecentPathService;
+import org.programmers.signalbuddyfinal.global.annotation.CurrentUser;
+import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
 import org.programmers.signalbuddyfinal.global.dto.PageResponse;
 import org.programmers.signalbuddyfinal.global.response.ApiResponse;
 import org.springframework.data.domain.Pageable;
@@ -169,4 +172,13 @@ public class MemberController {
         return memberService.restore(memberRestoreRequest);
     }
 
+    @PatchMapping("/{memberId}/notify-enabled")
+    public ResponseEntity<ApiResponse<Object>> updateNotifyEnabled(
+        @PathVariable("memberId") long memberId,
+        @CurrentUser CustomUser2Member user,
+        @Valid @RequestBody MemberNotiAllowRequest request
+    ) {
+        memberService.updateNotifyEnabled(memberId, user, request);
+        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+    }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/dto/MemberNotiAllowRequest.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/dto/MemberNotiAllowRequest.java
@@ -1,0 +1,13 @@
+package org.programmers.signalbuddyfinal.domain.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberNotiAllowRequest {
+
+    @NotNull(message = "알림 허용 여부는 비어있을 수 없습니다.")
+    private final Boolean notifyEnabled;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/dto/MemberResponse.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/dto/MemberResponse.java
@@ -1,5 +1,6 @@
 package org.programmers.signalbuddyfinal.domain.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,10 +13,11 @@ import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
 
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
 @EqualsAndHashCode
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberResponse {
 
     private Long memberId;
@@ -25,6 +27,8 @@ public class MemberResponse {
     private String nickname;
 
     private String profileImageUrl;
+
+    private Boolean notifyEnabled;
 
     private MemberRole role;
 

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/entity/Member.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/entity/Member.java
@@ -29,6 +29,10 @@ public class Member extends BaseTimeEntity {
 
     private String profileImageUrl;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean notifyEnabled = Boolean.TRUE;
+
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private MemberRole role;
@@ -71,4 +75,16 @@ public class Member extends BaseTimeEntity {
     }
 
     public void restore(){ this.memberStatus = MemberStatus.ACTIVITY; }
+
+    public boolean isNotificationEnabled() {
+        return Boolean.TRUE.equals(this.notifyEnabled);
+    }
+
+    public void updateNotifyEnabled(Boolean notifyEnabled) {
+        if (Boolean.FALSE.equals(notifyEnabled)) {
+            this.notifyEnabled = Boolean.FALSE;
+        } else if (Boolean.TRUE.equals(notifyEnabled)) {
+            this.notifyEnabled = Boolean.TRUE;
+        }
+    }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/member/exception/MemberErrorCode.java
@@ -15,7 +15,8 @@ public enum MemberErrorCode implements ErrorCode {
     WITHDRAWN_MEMBER(HttpStatus.FORBIDDEN, "06002", "탈퇴한 회원입니다."),
     ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, "06003", "이미 존재하는 닉네임 입니다."),
     ALREADY_EXIST_SOCIAL_ACCOUNT(HttpStatus.CONFLICT, "06004", "해당 소셜 계정은 이미 가입 되어있는 계정입니다."),
-    REQUIRED_EMAIL_DATA(HttpStatus.BAD_REQUEST, "06005", "해당 요청은 이메일이 필요합니다.");
+    REQUIRED_EMAIL_DATA(HttpStatus.BAD_REQUEST, "06005", "해당 요청은 이메일이 필요합니다."),
+    REQUESTER_IS_NOT_SAME(HttpStatus.FORBIDDEN, "06006", "요청자가 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/programmers/signalbuddyfinal/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/global/security/filter/JwtAuthorizationFilter.java
@@ -28,7 +28,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private final RedisTemplate<String, String> redisTemplate;
     private final Set<String> excludeGetPaths = Set.of(
         "/api/feedbacks/{feedbackId}/comments", "/api/crossroads/**", "/api/feedbacks",
-        "/api/crossroads/{crossroadId}/state"
+        "/api/crossroads/{crossroadId}/state", "/api/feedbacks/{feedbackId}"
     );
     private final Set<String> excludeAllPaths = Set.of(
         "/", "/docs/**", "/ws/**", "/actuator/health", "/webjars/**", "/api/auth/login",
@@ -78,7 +78,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
             request.setAttribute(EXCEPTION_ATTRIBUTE, "INVALID_TOKEN");
             throw new BusinessException(TokenErrorCode.INVALID_TOKEN);
-        };
+        }
 
         Authentication authentication = jwtUtil.getAuthentication(accessToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
@@ -752,7 +752,7 @@ class MemberControllerTest extends ControllerTest {
                             )
                             .pathParameters(
                                 parameterWithName("memberId").type(SimpleType.NUMBER)
-                                    .description("댓글을 수정할 피드백 ID")
+                                    .description("해당 계정의 memberId(PK)")
                             )
                             .requestFields(
                                 fieldWithPath("notifyEnabled").type(JsonFieldType.BOOLEAN)

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
@@ -14,6 +14,7 @@ import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGene
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.commonResponseFormat;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.getTokenExample;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.jwtFormat;
+import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.memberFormat;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.pageResponseFormat;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -117,19 +118,7 @@ class MemberControllerTest extends ControllerTest {
                     ResourceSnippetParameters.builder().tag(tag).summary("유저 정보 조회").pathParameters(
                             parameterWithName("id").type(SimpleType.NUMBER).description("유저 ID"))
                         .responseSchema(schema("MemberResponse")) // Schema 이름
-                        .responseFields(ArrayUtils.addAll(commonResponseFormat(),  // 공통 응답 필드 추가
-                            fieldWithPath("data.memberId").type(JsonFieldType.NUMBER)
-                                .description("유저 ID"),
-                            fieldWithPath("data.email").type(JsonFieldType.STRING)
-                                .description("유저 이메일"),
-                            fieldWithPath("data.nickname").type(JsonFieldType.STRING)
-                                .description("유저 닉네임"),
-                            fieldWithPath("data.profileImageUrl").type(JsonFieldType.STRING)
-                                .optional().description("프로필 이미지 URL"),
-                            fieldWithPath("data.role").type(JsonFieldType.STRING)
-                                .description("유저 역할"),
-                            fieldWithPath("data.memberStatus").type(JsonFieldType.STRING)
-                                .description("유저 상태"))).build())));
+                        .responseFields(memberFormat()).build())));
     }
 
     @DisplayName("유저 정보 수정")
@@ -164,20 +153,8 @@ class MemberControllerTest extends ControllerTest {
                             fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                             fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
                             fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"))
-                        .responseSchema(schema("MemberResponse")).responseFields(
-                            ArrayUtils.addAll(commonResponseFormat(),
-                                fieldWithPath("data.memberId").type(JsonFieldType.NUMBER)
-                                    .description("유저 ID"),
-                                fieldWithPath("data.email").type(JsonFieldType.STRING)
-                                    .description("유저 이메일"),
-                                fieldWithPath("data.nickname").type(JsonFieldType.STRING)
-                                    .description("유저 닉네임"),
-                                fieldWithPath("data.profileImageUrl").type(JsonFieldType.STRING)
-                                    .optional().description("프로필 이미지 URL"),
-                                fieldWithPath("data.role").type(JsonFieldType.STRING)
-                                    .description("유저 역할"),
-                                fieldWithPath("data.memberStatus").type(JsonFieldType.STRING)
-                                    .description("유저 상태"))).build())));
+                        .responseSchema(schema("MemberResponse"))
+                        .responseFields(memberFormat()).build())));
     }
 
     @DisplayName("유저 프로필 이미지 변경")
@@ -737,20 +714,8 @@ class MemberControllerTest extends ControllerTest {
                                 fieldWithPath("email").type(JsonFieldType.STRING)
                                     .description("계정을 복구하고자 하는 이메일")
                             )
-                            .responseSchema(schema("MemberResponse")).responseFields(
-                                ArrayUtils.addAll(commonResponseFormat(),
-                                    fieldWithPath("data.memberId").type(JsonFieldType.NUMBER)
-                                        .description("유저 ID"),
-                                    fieldWithPath("data.email").type(JsonFieldType.STRING)
-                                        .description("유저 이메일"),
-                                    fieldWithPath("data.nickname").type(JsonFieldType.STRING)
-                                        .description("유저 닉네임"),
-                                    fieldWithPath("data.profileImageUrl").type(JsonFieldType.STRING)
-                                        .optional().description("프로필 이미지 URL"),
-                                    fieldWithPath("data.role").type(JsonFieldType.STRING)
-                                        .description("유저 역할"),
-                                    fieldWithPath("data.memberStatus").type(JsonFieldType.STRING)
-                                        .description("유저 상태"))).build())));
+                            .responseSchema(schema("MemberResponse"))
+                            .responseFields(memberFormat()).build())));
 
     }
 

--- a/src/test/java/org/programmers/signalbuddyfinal/global/support/RestDocsFormatGenerators.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/global/support/RestDocsFormatGenerators.java
@@ -66,7 +66,7 @@ public final class RestDocsFormatGenerators {
     public static FieldDescriptor[] pageResponseWithMemberFormat() {
         FieldDescriptor[] pageDocs = pageResponseFormat();
 
-        FieldDescriptor[] memberDocs = new FieldDescriptor[7];
+        FieldDescriptor[] memberDocs = new FieldDescriptor[8];
         memberDocs[0] = fieldWithPath("data.searchResults[].member")
             .type(JsonFieldType.OBJECT)
             .description("작성자 정보");
@@ -82,14 +82,21 @@ public final class RestDocsFormatGenerators {
         memberDocs[4] = fieldWithPath("data.searchResults[].member.profileImageUrl")
             .type(JsonFieldType.STRING)
             .description("작성자의 프로필 이미지 URL");
-        memberDocs[5] = fieldWithPath("data.searchResults[].member.role")
+        memberDocs[5] = fieldWithPath("data.searchResults[].member.notifyEnabled")
+            .type(JsonFieldType.BOOLEAN)
+            .description("""
+                알림 설정
+                - `true` : 알림 허용
+                - `false` : 알림 거부
+                """).optional();
+        memberDocs[6] = fieldWithPath("data.searchResults[].member.role")
             .type(JsonFieldType.STRING)
             .description("""
                 작성자의 권한
                 - USER : 일반 사용자
                 - ADMIN : 관리자
                 """);
-        memberDocs[6] = fieldWithPath("data.searchResults[].member.memberStatus")
+        memberDocs[7] = fieldWithPath("data.searchResults[].member.memberStatus")
             .type(JsonFieldType.STRING)
             .description("""
                 작성자의 탈퇴 여부
@@ -104,8 +111,7 @@ public final class RestDocsFormatGenerators {
     public static FieldDescriptor[] commonResponseWithMemberFormat() {
         FieldDescriptor[] commonDocs = commonResponseFormat();
 
-        FieldDescriptor[] memberDocs = new FieldDescriptor[7];
-
+        FieldDescriptor[] memberDocs = new FieldDescriptor[8];
         memberDocs[0] = fieldWithPath("data.member")
             .type(JsonFieldType.OBJECT)
             .description("작성자 정보");
@@ -121,14 +127,63 @@ public final class RestDocsFormatGenerators {
         memberDocs[4] = fieldWithPath("data.member.profileImageUrl")
             .type(JsonFieldType.STRING)
             .description("작성자의 프로필 이미지 URL");
-        memberDocs[5] = fieldWithPath("data.member.role")
+        memberDocs[5] = fieldWithPath("data.member.notifyEnabled")
+            .type(JsonFieldType.BOOLEAN)
+            .description("""
+                알림 설정
+                - `true` : 알림 허용
+                - `false` : 알림 거부
+                """).optional();
+        memberDocs[6] = fieldWithPath("data.member.role")
             .type(JsonFieldType.STRING)
             .description("""
                 작성자의 권한
                 - `USER` : 일반 사용자
                 - `ADMIN` : 관리자
                 """);
-        memberDocs[6] = fieldWithPath("data.member.memberStatus")
+        memberDocs[7] = fieldWithPath("data.member.memberStatus")
+            .type(JsonFieldType.STRING)
+            .description("""
+                작성자의 탈퇴 여부
+                - `ACTIVITY` : 활동 상태
+                - `WITHDRAWAL` : 탈퇴 상태
+                """);
+
+        return Stream.concat(Arrays.stream(commonDocs), Arrays.stream(memberDocs))
+            .toArray(FieldDescriptor[]::new);
+    }
+
+    public static FieldDescriptor[] memberFormat() {
+        FieldDescriptor[] commonDocs = commonResponseFormat();
+
+        FieldDescriptor[] memberDocs = new FieldDescriptor[7];
+        memberDocs[0] = fieldWithPath("data.memberId")
+            .type(JsonFieldType.NUMBER)
+            .description("작성자 ID(PK)");
+        memberDocs[1] = fieldWithPath("data.email")
+            .type(JsonFieldType.STRING)
+            .description("작성자의 이메일");
+        memberDocs[2] = fieldWithPath("data.nickname")
+            .type(JsonFieldType.STRING)
+            .description("작성자의 닉네임");
+        memberDocs[3] = fieldWithPath("data.profileImageUrl")
+            .type(JsonFieldType.STRING)
+            .description("작성자의 프로필 이미지 URL").optional();
+        memberDocs[4] = fieldWithPath("data.notifyEnabled")
+            .type(JsonFieldType.BOOLEAN)
+            .description("""
+                알림 설정
+                - `true` : 알림 허용
+                - `false` : 알림 거부
+                """).optional();
+        memberDocs[5] = fieldWithPath("data.role")
+            .type(JsonFieldType.STRING)
+            .description("""
+                작성자의 권한
+                - `USER` : 일반 사용자
+                - `ADMIN` : 관리자
+                """);
+        memberDocs[6] = fieldWithPath("data.memberStatus")
             .type(JsonFieldType.STRING)
             .description("""
                 작성자의 탈퇴 여부


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #142, #147


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> Member 필드에 notifyEnabled 필드를 추가하여 알림 설정을 할 수 있게 추가했습니다!
> 피드백 상세 조회 API를 JWT Filter가 차단하는 문제도 해결했습니다!


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> MemberResponse 객체만 반환하는 경우에는  `RestDocsFormatGenerators`에 `memberFormat()`를 사용하시면 코드를 줄일 수 있습니다!

