### PR TITLE
[Feature] 미세먼지 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,9 @@ dependencies {
     // Log
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 
+    // Xml
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.19.0-rc2"
+
 }
 
 // JaCoCo 버전 설정

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityController.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityController.java
@@ -1,0 +1,23 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQualityResponse;
+import org.programmers.signalbuddyfinal.domain.air_quality.service.AirQualityService;
+import org.programmers.signalbuddyfinal.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/air-quality")
+@RequiredArgsConstructor
+public class AirQualityController {
+
+    private final AirQualityService airQualityService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<AirQualityResponse>> getAirQuality() {
+        return ResponseEntity.ok(ApiResponse.createSuccess(airQualityService.getAirQuality()));
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityScheduler.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityScheduler.java
@@ -1,0 +1,22 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.controller;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.programmers.signalbuddyfinal.domain.air_quality.service.AirQualityService;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@RequiredArgsConstructor
+public class AirQualityScheduler {
+    private final AirQualityService airQualityService;
+
+    @Scheduled(cron = "${schedule.air-quality-api.cron}")
+    @SchedulerLock(
+        name = "updateAirQualityScheduler",
+        lockAtMostFor = "${schedule.air-quality-api.lockAtMostFor}",
+        lockAtLeastFor = "${schedule.air-quality-api.lockAtLeastFor}")
+    public void updateAirQuality(){
+        airQualityService.updateAriQuality();
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityScheduler.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityScheduler.java
@@ -5,17 +5,19 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.programmers.signalbuddyfinal.domain.air_quality.service.AirQualityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
-@Configuration
+@Component
 @RequiredArgsConstructor
 public class AirQualityScheduler {
     private final AirQualityService airQualityService;
 
-    @Scheduled(cron = "${schedule.air-quality-api.cron}")
+    @Scheduled(cron = "${schedule.air-quality-api.cron:0 0/1 * * * ?}")
     @SchedulerLock(
         name = "updateAirQualityScheduler",
-        lockAtMostFor = "${schedule.air-quality-api.lockAtMostFor}",
-        lockAtLeastFor = "${schedule.air-quality-api.lockAtLeastFor}")
+        lockAtMostFor = "${schedule.air-quality-api.lockAtMostFor:5m}",
+        lockAtLeastFor = "${schedule.air-quality-api.lockAtLeastFor:50m}"
+    )
     public void updateAirQuality(){
         airQualityService.updateAriQuality();
     }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityScheduler.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityScheduler.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-@Component
+@Configuration
 @RequiredArgsConstructor
 public class AirQualityScheduler {
     private final AirQualityService airQualityService;

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityScheduler.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityScheduler.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-@Configuration
+@Component
 @RequiredArgsConstructor
 public class AirQualityScheduler {
     private final AirQualityService airQualityService;

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQuality.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQuality.java
@@ -1,0 +1,16 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class AirQuality {
+
+    private int list_total_count;
+
+    @JsonProperty("RESULT")
+    private Result result;
+
+    private List<AirQualityItems> row;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQualityItems.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQualityItems.java
@@ -1,0 +1,36 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class AirQualityItems {
+
+    @JsonProperty("GRADE")
+    private String grade;
+
+    @JsonProperty("IDEX_MVL")
+    private String mvl;
+
+    @JsonProperty("POLLUTANT")
+    private String pollutant;
+
+    @JsonProperty("NITROGEN")
+    private String nitrogen;
+
+    @JsonProperty("OZONE")
+    private String ozone;
+
+    @JsonProperty("CARBON")
+    private String carbon;
+
+    @JsonProperty("SULFUROUS")
+    private String sulfurous;
+
+    @JsonProperty("PM10")
+    private String pm10;
+
+    @JsonProperty("PM25")
+    private String pm25;
+
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQualityResponse.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQualityResponse.java
@@ -1,13 +1,17 @@
 package org.programmers.signalbuddyfinal.domain.air_quality.dto;
 
 import java.io.Serializable;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class AirQualityResponse implements Serializable {
     private String grade;
     private String pm10;

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQualityResponse.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQualityResponse.java
@@ -1,0 +1,16 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.dto;
+
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Data
+public class AirQualityResponse implements Serializable {
+
+    private String grade;
+    private String pm10;
+    private String pm25;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQualityResponse.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/AirQualityResponse.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 @Builder
 @Data
 public class AirQualityResponse implements Serializable {
-
     private String grade;
     private String pm10;
     private String pm25;

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/CachedAirQuality.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/CachedAirQuality.java
@@ -1,0 +1,17 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CachedAirQuality implements Serializable {
+
+    private AirQualityResponse data;
+
+    private boolean fresh;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/CachedAirQuality.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/CachedAirQuality.java
@@ -1,17 +1,21 @@
 package org.programmers.signalbuddyfinal.domain.air_quality.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class CachedAirQuality implements Serializable {
 
     private AirQualityResponse data;
 
     private boolean fresh;
-
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/Result.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/dto/Result.java
@@ -1,0 +1,19 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.Getter;
+
+@Getter
+@JacksonXmlRootElement(localName = "RESULT")
+public class Result {
+
+    @JsonProperty("CODE")
+    @JacksonXmlProperty(localName = "CODE")
+    private String code;
+
+    @JsonProperty("MESSAGE")
+    @JacksonXmlProperty(localName = "MESSAGE")
+    private String message;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/exception/AirQualityErrorCode.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/exception/AirQualityErrorCode.java
@@ -1,0 +1,20 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.programmers.signalbuddyfinal.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum AirQualityErrorCode implements ErrorCode {
+
+    AIR_QUALITY_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "20000",
+        "일시적인 문제로 데이터를 불러올 수 없습니다. 잠시 후 다시 시도해 주세요."),
+    AIR_QUALITY_DATA_NOT_READ(HttpStatus.INTERNAL_SERVER_ERROR, "20001", "미세먼지 API 데이터 파싱 에러");
+
+    private HttpStatus httpStatus;
+    private String code;
+    private String message;
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityProvider.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityProvider.java
@@ -1,0 +1,74 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.service;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.sl.draw.geom.GuideIf.Op;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQuality;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQualityItems;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.Result;
+import org.programmers.signalbuddyfinal.domain.air_quality.exception.AirQualityErrorCode;
+import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AirQualityProvider {
+
+    @Qualifier("airQualityApiWebClient")
+    private final WebClient webClient;
+    @Value("${air-quality.api-key}")
+    private String apiKey;
+    private final ObjectMapper objectMapper;
+    private final XmlMapper xmlMapper = (XmlMapper) new XmlMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+
+    public Optional<AirQuality> getAirQuality() {
+
+            String body = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/{apiKey}/json/ListAvgOfSeoulAirQualityService/{start}/{end}")
+                    .build(apiKey, 1, 1)
+                )
+                .accept(MediaType.ALL)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+            AirQuality airQuality = parseAirQuality(body);
+        if(airQuality != null) {
+            return Optional.of(airQuality);
+        }
+        return Optional.empty();
+    }
+
+    private AirQuality parseAirQuality(String body) {
+        try {
+            JsonNode jsonRoot = objectMapper.readTree(body);
+            if (jsonRoot.has("ListAvgOfSeoulAirQualityService")) {
+                JsonNode service = jsonRoot.get("ListAvgOfSeoulAirQualityService");
+                return objectMapper.treeToValue(service, AirQuality.class);
+            }
+        } catch (Exception e) {
+            try {
+                Result error = xmlMapper.readValue(body, Result.class);
+                log.info("미세먼지 API 응답 실패 - CODE: {}, MESSAGE: {}", error.getCode(),
+                    error.getMessage());
+                return null;
+            } catch (Exception xmlEx) {
+                throw new BusinessException(AirQualityErrorCode.AIR_QUALITY_DATA_NOT_READ);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityService.java
@@ -1,0 +1,66 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQuality;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQualityResponse;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.CachedAirQuality;
+import org.programmers.signalbuddyfinal.domain.air_quality.exception.AirQualityErrorCode;
+import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AirQualityService {
+
+    private final AirQualityProvider airQualityProvider;
+    private final RedisTemplate<String, CachedAirQuality> redisTemplate;
+
+    private static final String key = "air-quality: ";
+    private static final Duration TTL = Duration.ofHours(2);
+
+    public AirQualityResponse getAirQuality() {
+        CachedAirQuality cached = redisTemplate.opsForValue().get(key);
+        if (cached != null && cached.isFresh()) {
+            return cached.getData();
+        }
+        return updateAriQuality();
+    }
+
+    public AirQualityResponse updateAriQuality() {
+        Optional<AirQuality> airQuality = airQualityProvider.getAirQuality();
+
+        // 응답 성공
+        if (airQuality.isPresent()) {
+            AirQualityResponse response = createResponse(airQuality);
+            saveToCache(response, true);
+            return response;
+        } else {
+            // 응답 실패
+            CachedAirQuality previous = redisTemplate.opsForValue().get(key);
+            if (previous != null) {
+                saveToCache(previous.getData(), false);
+                return previous.getData();
+            }
+            throw new BusinessException(AirQualityErrorCode.AIR_QUALITY_SERVICE_UNAVAILABLE);
+        }
+    }
+
+    private AirQualityResponse createResponse(Optional<AirQuality> airQuality) {
+        return AirQualityResponse.builder()
+            .grade(airQuality.get().getRow().get(0).getGrade())
+            .pm25(airQuality.get().getRow().get(0).getPm25())
+            .pm10(airQuality.get().getRow().get(0).getPm10())
+            .build();
+    }
+
+    private void saveToCache(AirQualityResponse airQualityResponse, boolean fresh) {
+        redisTemplate.opsForValue().set(key, new CachedAirQuality(airQualityResponse, fresh,
+            LocalDateTime.now()), TTL);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityService.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityService.java
@@ -1,7 +1,6 @@
 package org.programmers.signalbuddyfinal.domain.air_quality.service;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,13 +18,13 @@ import org.springframework.stereotype.Service;
 public class AirQualityService {
 
     private final AirQualityProvider airQualityProvider;
-    private final RedisTemplate<String, CachedAirQuality> redisTemplate;
+    private final RedisTemplate<Object, Object> redisTemplate;
 
     private static final String key = "air-quality: ";
     private static final Duration TTL = Duration.ofHours(2);
 
     public AirQualityResponse getAirQuality() {
-        CachedAirQuality cached = redisTemplate.opsForValue().get(key);
+        CachedAirQuality cached = (CachedAirQuality) redisTemplate.opsForValue().get(key);
         if (cached != null && cached.isFresh()) {
             return cached.getData();
         }
@@ -42,7 +41,7 @@ public class AirQualityService {
             return response;
         } else {
             // 응답 실패
-            CachedAirQuality previous = redisTemplate.opsForValue().get(key);
+            CachedAirQuality previous = (CachedAirQuality) redisTemplate.opsForValue().get(key);
             if (previous != null) {
                 saveToCache(previous.getData(), false);
                 return previous.getData();
@@ -60,7 +59,6 @@ public class AirQualityService {
     }
 
     private void saveToCache(AirQualityResponse airQualityResponse, boolean fresh) {
-        redisTemplate.opsForValue().set(key, new CachedAirQuality(airQualityResponse, fresh,
-            LocalDateTime.now()), TTL);
+        redisTemplate.opsForValue().set(key, new CachedAirQuality(airQualityResponse, fresh), TTL);
     }
 }

--- a/src/main/java/org/programmers/signalbuddyfinal/global/config/WebClientConfig.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/global/config/WebClientConfig.java
@@ -23,6 +23,9 @@ public class WebClientConfig {
     @Value("${weather.base-url}")
     private String weatherApiBaseUrl;
 
+    @Value("${air-quality.base-url}")
+    private String airQualityApiBaseUrl;
+
     private final int processors = Runtime.getRuntime().availableProcessors();    // PC의 Processor 개수
     private final HttpClient httpClient = HttpClient.create(
             ConnectionProvider.builder("ApiConnections")
@@ -48,6 +51,16 @@ public class WebClientConfig {
     public WebClient weatherApiWebClient() {
         return WebClient.builder()
             .baseUrl(weatherApiBaseUrl)
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+    // 미세먼지 API WebClient
+    @Bean
+    public WebClient airQualityApiWebClient() {
+        return WebClient.builder()
+            .baseUrl(airQualityApiBaseUrl)
             .clientConnector(new ReactorClientHttpConnector(httpClient))
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .build();

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/AirQualityServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/AirQualityServiceTest.java
@@ -1,0 +1,189 @@
+package org.programmers.signalbuddyfinal.domain.air_quality;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQualityResponse;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.CachedAirQuality;
+import org.programmers.signalbuddyfinal.domain.air_quality.service.AirQualityService;
+import org.programmers.signalbuddyfinal.global.config.RedisConfig;
+import org.programmers.signalbuddyfinal.global.db.RedisTestContainer;
+import org.programmers.signalbuddyfinal.global.exception.BusinessException;
+import org.programmers.signalbuddyfinal.global.support.ServiceTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ContextConfiguration(initializers = AirQualityServiceTest.MockServerInitializer.class)
+@Import(RedisConfig.class)
+@TestPropertySource(properties = {
+    "schedule.air-quality-api.cron=0 0 0/1 * * ?",
+    "schedule.air-quality-api.lockAtMostFor=10m",
+    "schedule.air-quality-api.lockAtLeastFor=50m"
+})
+
+public class AirQualityServiceTest extends ServiceTest implements RedisTestContainer {
+
+    @Autowired
+    private AirQualityService airQualityService;
+    @Autowired
+    private RedisTemplate<String, CachedAirQuality> redisTemplate;
+    private static MockWebServer mockWebServer;
+    private String key = "air-quality: ";
+    private static CachedAirQuality cache;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        AirQualityResponse airQualityResponse = AirQualityResponse.builder()
+            .grade("보통")
+            .pm10("61")
+            .pm25("20")
+            .build();
+        cache = new CachedAirQuality(airQualityResponse, true,
+            LocalDateTime.of(2025, 1, 1, 1, 1));
+    }
+
+    @BeforeEach
+    void clearRedis() {
+        RedisConnectionFactory factory = redisTemplate.getConnectionFactory();
+        if (factory != null) {
+            factory.getConnection().serverCommands().flushAll();
+        }
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    public static class MockServerInitializer implements
+        ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(ConfigurableApplicationContext applicationContext) {
+            String baseUrl = "http://localhost:" + mockWebServer.getPort();
+            TestPropertyValues.of("air-quality.base-url=" + baseUrl)
+                .applyTo(applicationContext.getEnvironment());
+        }
+    }
+
+    @DisplayName("첫 요청 청공 시 응답 반환 및 캐싱 테스트")
+    @Test
+    void successRequestTest() {
+        createMockWebServer(createResponse());
+
+        AirQualityResponse response = airQualityService.getAirQuality();
+        CachedAirQuality cache = redisTemplate.opsForValue().get(key);
+
+        assertThat(response.getGrade()).isEqualTo("보통");
+        assertThat(cache).isNotNull();
+        assertThat(cache.getData().getGrade()).isEqualTo("보통");
+        assertThat(cache.isFresh()).isTrue();
+    }
+
+    @DisplayName("두번 째 요청시 캐싱된 데이터 반환")
+    @Test
+    void successSecondRequestTest() {
+
+        int count = mockWebServer.getRequestCount();
+        createMockWebServer(createResponse());
+        redisTemplate.opsForValue().set(key, cache);
+
+        AirQualityResponse response = airQualityService.getAirQuality();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getGrade()).isEqualTo("보통");
+        assertThat(response.getPm10()).isEqualTo("61");
+        assertThat(response.getPm25()).isEqualTo("20");
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(count);
+    }
+
+    @DisplayName("failBack 실패 테스트")
+    @Test
+    void failBackRequestTest() {
+        createMockWebServer(createFailResponse());
+        assertThrows(BusinessException.class, () -> airQualityService.getAirQuality());
+    }
+
+    @DisplayName("failBack 성공 테스트")
+    @Test
+    void failBackSuccessTest() {
+
+        createMockWebServer(createFailResponse());
+        redisTemplate.opsForValue().set(key, cache);
+        CachedAirQuality before = redisTemplate.opsForValue().get(key);
+
+        airQualityService.updateAriQuality();
+        CachedAirQuality after = redisTemplate.opsForValue().get(key);
+
+        assertThat(after.isFresh()).isFalse();
+        assertThat(after.getData()).isEqualTo(before.getData());
+
+    }
+
+    private void createMockWebServer(String response){
+        mockWebServer.enqueue(new MockResponse()
+            .setBody(response)
+            .addHeader("Content-Type", "application/json")
+            .setResponseCode(200)
+        );
+    }
+
+    private String createResponse() {
+        return """
+                {
+                  "ListAvgOfSeoulAirQualityService": {
+                    "list_total_count": 1,
+                    "RESULT": {
+                      "CODE": "INFO-000",
+                      "MESSAGE": "정상 처리되었습니다"
+                    },
+                    "row": [
+                      {
+                        "GRADE": "보통",
+                        "IDEX_MVL": "55",
+                        "POLLUTANT": "O3",
+                        "NITROGEN": 0.017,
+                        "OZONE": 0.036,
+                        "CARBON": 0.4,
+                        "SULFUROUS": 0.003,
+                        "PM10": 23,
+                        "PM25": 12
+                      }
+                    ]
+                  }
+                }
+            """;
+    }
+
+    private String createFailResponse() {
+        return "<RESULT>\n"
+            + "<script/>\n"
+            + "<script/>\n"
+            + "<CODE>ERROR-300</CODE>\n"
+            + "<MESSAGE>\n"
+            + "<![CDATA[ 필수 값이 누락되어 있습니다. 요청인자를 참고 하십시오. ]]>\n"
+            + "</MESSAGE>\n"
+            + "</RESULT>";
+    }
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityControllerTest.java
@@ -1,4 +1,66 @@
 package org.programmers.signalbuddyfinal.domain.air_quality.controller;
 
-public class AirQualityControllerTest {
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.BDDMockito.given;
+import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.commonResponseFormat;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQualityResponse;
+import org.programmers.signalbuddyfinal.domain.air_quality.service.AirQualityService;
+import org.programmers.signalbuddyfinal.global.support.ControllerTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
+@WebMvcTest(AirQualityController.class)
+public class AirQualityControllerTest extends ControllerTest {
+
+    private final String tag = "AirQuality API";
+
+    @MockitoBean
+    private AirQualityService airQualityService;
+
+    @DisplayName("미세먼지 조회")
+    @Test
+    void getAirQuality() throws Exception {
+        final AirQualityResponse response = AirQualityResponse.builder()
+            .grade("보통")
+            .pm25("20")
+            .pm10("25")
+            .build();
+
+        given(airQualityService.getAirQuality()).willReturn(response);
+
+        mockMvc.perform(get("/api/air-quality"))
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andDo(document("미세먼지 조회",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .tag(tag)
+                        .summary("미세먼지 조회")
+                        .description("미세먼지 API를 요청하는 API")
+                        .responseFields(
+                            ArrayUtils.addAll(
+                                commonResponseFormat(),
+                                fieldWithPath("data.grade").description("미세먼지 등급"),
+                                fieldWithPath("data.pm10").description("미세먼지(PM10) 수치"),
+                                fieldWithPath("data.pm25").description("초미세먼지(PM2.5) 수치")
+                            )
+                        )
+                        .build()
+                )
+            ));
+    }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityControllerTest.java
@@ -1,0 +1,4 @@
+package org.programmers.signalbuddyfinal.domain.air_quality.controller;
+
+public class AirQualityControllerTest {
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityServiceTest.java
@@ -1,13 +1,12 @@
 package org.programmers.signalbuddyfinal.domain.air_quality.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQualityResponse;
@@ -18,73 +17,65 @@ import org.programmers.signalbuddyfinal.global.exception.BusinessException;
 import org.programmers.signalbuddyfinal.global.support.ServiceTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
+import java.io.IOException;
+
 @SpringBootTest
-@ContextConfiguration(initializers = AirQualityServiceTest.MockServerInitializer.class)
 @Import(RedisConfig.class)
 @TestPropertySource(properties = {
     "schedule.air-quality-api.cron=0 0 0/1 * * ?",
     "schedule.air-quality-api.lockAtMostFor=10m",
     "schedule.air-quality-api.lockAtLeastFor=50m"
 })
-
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class AirQualityServiceTest extends ServiceTest implements RedisTestContainer {
 
     @Autowired
     private AirQualityService airQualityService;
+
     @Autowired
     private RedisTemplate<Object, Object> redisTemplate;
+
     private static MockWebServer mockWebServer;
-    private String key = "air-quality: ";
-    private static CachedAirQuality cache;
+
+    private final String key = "air-quality: ";
+
+    private static CachedAirQuality cachedAirQuality;
 
     @BeforeAll
-    static void setUp() throws Exception {
+    static void startMockServer() throws IOException {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
-        AirQualityResponse airQualityResponse = AirQualityResponse.builder()
+
+        AirQualityResponse response = AirQualityResponse.builder()
             .grade("보통")
             .pm10("61")
             .pm25("20")
             .build();
-        cache = new CachedAirQuality(airQualityResponse, true);
-    }
-
-    @BeforeEach
-    void clearRedis() {
-        RedisConnectionFactory factory = redisTemplate.getConnectionFactory();
-        if (factory != null) {
-            factory.getConnection().serverCommands().flushAll();
-        }
+        cachedAirQuality = new CachedAirQuality(response, true);
     }
 
     @AfterAll
-    static void tearDown() throws Exception {
+    static void stopMockServer() throws IOException {
         mockWebServer.shutdown();
     }
 
-    public static class MockServerInitializer implements
-        ApplicationContextInitializer<ConfigurableApplicationContext> {
-
-        @Override
-        public void initialize(ConfigurableApplicationContext applicationContext) {
-            String baseUrl = "http://localhost:" + mockWebServer.getPort();
-            TestPropertyValues.of("air-quality.base-url=" + baseUrl)
-                .applyTo(applicationContext.getEnvironment());
-        }
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("air-quality.base-url", () -> "http://localhost:" + mockWebServer.getPort());
     }
 
-    @DisplayName("첫 요청 청공 시 응답 반환 및 캐싱 테스트")
+    @DisplayName("첫 요청 성공 시 응답 반환 및 캐싱 테스트")
     @Test
     void successRequestTest() {
+        flushRedis();
         createMockWebServer(createResponse());
 
         AirQualityResponse response = airQualityService.getAirQuality();
@@ -96,13 +87,13 @@ public class AirQualityServiceTest extends ServiceTest implements RedisTestConta
         assertThat(cache.isFresh()).isTrue();
     }
 
-    @DisplayName("두번 째 요청시 캐싱된 데이터 반환")
+    @DisplayName("두 번째 요청 시 캐싱된 데이터 반환")
     @Test
     void successSecondRequestTest() {
-
+        flushRedis();
         int count = mockWebServer.getRequestCount();
         createMockWebServer(createResponse());
-        redisTemplate.opsForValue().set(key, cache);
+        redisTemplate.opsForValue().set(key, cachedAirQuality);
 
         AirQualityResponse response = airQualityService.getAirQuality();
 
@@ -116,16 +107,18 @@ public class AirQualityServiceTest extends ServiceTest implements RedisTestConta
     @DisplayName("failBack 실패 테스트")
     @Test
     void failBackRequestTest() {
+        flushRedis();
         createMockWebServer(createFailResponse());
+
         assertThrows(BusinessException.class, () -> airQualityService.getAirQuality());
     }
 
     @DisplayName("failBack 성공 테스트")
     @Test
     void failBackSuccessTest() {
-
+        flushRedis();
         createMockWebServer(createFailResponse());
-        redisTemplate.opsForValue().set(key, cache);
+        redisTemplate.opsForValue().set(key, cachedAirQuality);
         CachedAirQuality before = (CachedAirQuality) redisTemplate.opsForValue().get(key);
 
         airQualityService.updateAriQuality();
@@ -133,15 +126,20 @@ public class AirQualityServiceTest extends ServiceTest implements RedisTestConta
 
         assertThat(after.isFresh()).isFalse();
         assertThat(after.getData()).isEqualTo(before.getData());
-
     }
 
-    private void createMockWebServer(String response){
+    private void flushRedis() {
+        RedisConnectionFactory factory = redisTemplate.getConnectionFactory();
+        if (factory != null) {
+            factory.getConnection().serverCommands().flushAll();
+        }
+    }
+
+    private void createMockWebServer(String response) {
         mockWebServer.enqueue(new MockResponse()
             .setBody(response)
             .addHeader("Content-Type", "application/json")
-            .setResponseCode(200)
-        );
+            .setResponseCode(200));
     }
 
     private String createResponse() {
@@ -172,13 +170,15 @@ public class AirQualityServiceTest extends ServiceTest implements RedisTestConta
     }
 
     private String createFailResponse() {
-        return "<RESULT>\n"
-            + "<script/>\n"
-            + "<script/>\n"
-            + "<CODE>ERROR-300</CODE>\n"
-            + "<MESSAGE>\n"
-            + "<![CDATA[ 필수 값이 누락되어 있습니다. 요청인자를 참고 하십시오. ]]>\n"
-            + "</MESSAGE>\n"
-            + "</RESULT>";
+        return """
+                <RESULT>
+                <script/>
+                <script/>
+                <CODE>ERROR-300</CODE>
+                <MESSAGE>
+                <![CDATA[ 필수 값이 누락되어 있습니다. 요청인자를 참고 하십시오. ]]>
+                </MESSAGE>
+                </RESULT>
+            """;
     }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityServiceTest.java
@@ -3,7 +3,6 @@ package org.programmers.signalbuddyfinal.domain.air_quality.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDateTime;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
@@ -42,7 +41,7 @@ public class AirQualityServiceTest extends ServiceTest implements RedisTestConta
     @Autowired
     private AirQualityService airQualityService;
     @Autowired
-    private RedisTemplate<String, CachedAirQuality> redisTemplate;
+    private RedisTemplate<Object, Object> redisTemplate;
     private static MockWebServer mockWebServer;
     private String key = "air-quality: ";
     private static CachedAirQuality cache;
@@ -56,8 +55,7 @@ public class AirQualityServiceTest extends ServiceTest implements RedisTestConta
             .pm10("61")
             .pm25("20")
             .build();
-        cache = new CachedAirQuality(airQualityResponse, true,
-            LocalDateTime.of(2025, 1, 1, 1, 1));
+        cache = new CachedAirQuality(airQualityResponse, true);
     }
 
     @BeforeEach
@@ -90,7 +88,7 @@ public class AirQualityServiceTest extends ServiceTest implements RedisTestConta
         createMockWebServer(createResponse());
 
         AirQualityResponse response = airQualityService.getAirQuality();
-        CachedAirQuality cache = redisTemplate.opsForValue().get(key);
+        CachedAirQuality cache = (CachedAirQuality) redisTemplate.opsForValue().get(key);
 
         assertThat(response.getGrade()).isEqualTo("보통");
         assertThat(cache).isNotNull();
@@ -128,10 +126,10 @@ public class AirQualityServiceTest extends ServiceTest implements RedisTestConta
 
         createMockWebServer(createFailResponse());
         redisTemplate.opsForValue().set(key, cache);
-        CachedAirQuality before = redisTemplate.opsForValue().get(key);
+        CachedAirQuality before = (CachedAirQuality) redisTemplate.opsForValue().get(key);
 
         airQualityService.updateAriQuality();
-        CachedAirQuality after = redisTemplate.opsForValue().get(key);
+        CachedAirQuality after = (CachedAirQuality) redisTemplate.opsForValue().get(key);
 
         assertThat(after.isFresh()).isFalse();
         assertThat(after.getData()).isEqualTo(before.getData());

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/service/AirQualityServiceTest.java
@@ -1,4 +1,4 @@
-package org.programmers.signalbuddyfinal.domain.air_quality;
+package org.programmers.signalbuddyfinal.domain.air_quality.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -6,16 +6,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.LocalDateTime;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQualityResponse;
 import org.programmers.signalbuddyfinal.domain.air_quality.dto.CachedAirQuality;
-import org.programmers.signalbuddyfinal.domain.air_quality.service.AirQualityService;
 import org.programmers.signalbuddyfinal.global.config.RedisConfig;
 import org.programmers.signalbuddyfinal.global.db.RedisTestContainer;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;

--- a/src/test/java/org/programmers/signalbuddyfinal/global/config/RedisConfig.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/global/config/RedisConfig.java
@@ -34,6 +34,13 @@ public class RedisConfig {
     }
 
     @Bean
+    public RedisTemplate<String, CachedAirQuality> cachedAirQualityRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, CachedAirQuality> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+
+    @Bean
     public PlatformTransactionManager transactionManager() {
         return new JpaTransactionManager();
     }

--- a/src/test/java/org/programmers/signalbuddyfinal/global/config/RedisConfig.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/global/config/RedisConfig.java
@@ -34,13 +34,6 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, CachedAirQuality> cachedAirQualityRedisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, CachedAirQuality> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        return template;
-    }
-
-    @Bean
     public PlatformTransactionManager transactionManager() {
         return new JpaTransactionManager();
     }

--- a/src/test/java/org/programmers/signalbuddyfinal/global/config/RedisConfig.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package org.programmers.signalbuddyfinal.global.config;
 
+import org.programmers.signalbuddyfinal.domain.air_quality.dto.CachedAirQuality;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -30,6 +31,13 @@ public class RedisConfig {
         redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, CachedAirQuality> cachedAirQualityRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, CachedAirQuality> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
     }
 
     @Bean


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #213 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 서울시 평균 대기 상태 API 연동
1. 스케줄러 기반 요청 : 1시간마다 `ListAvgOfSeoulAirQualityService`에 요청하여 평균 대기질 조회합니다.
2. 사용자 직접 요청 : 클라이언트가 /air-quality API를 호출하면`ListAvgOfSeoulAirQualityService`에 요청하여 평균 대기질 조회합니다.

## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 여기에 작성

