### PR TITLE
[Fix] 이메일 전송 테스트 대기 시간 연장

### DIFF
--- a/src/test/java/org/programmers/signalbuddyfinal/domain/auth/service/EmailServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/auth/service/EmailServiceTest.java
@@ -1,9 +1,7 @@
 package org.programmers.signalbuddyfinal.domain.auth.service;
 
-
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
-
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,11 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @EnableAsync
-@Transactional
 class EmailServiceTest extends ServiceTest implements RedisTestContainer {
 
     @Autowired
@@ -41,10 +37,15 @@ class EmailServiceTest extends ServiceTest implements RedisTestContainer {
         emailService.sendEmail("test@test.com");
 
         // then
-        await().atMost(4, TimeUnit.SECONDS)
+        await().atMost(10, TimeUnit.SECONDS)
+            .pollDelay(2, TimeUnit.SECONDS)
+            .pollInterval(500, TimeUnit.MILLISECONDS)
             .untilAsserted(() -> {
-                assertTrue(redisTemplate.hasKey(PREFIX + "test@test.com"));
+                boolean exists = redisTemplate.hasKey(PREFIX + "test@test.com");
+                assertTrue(exists);
             });
+
+        redisTemplate.delete(PREFIX + "test@test.com");
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #250 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 실제 Redis에 값이 저장되기까지의 비동기 처리 지연을 고려하여, 대기 시간을 5초에서 10초로 연장했습니다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 여기에 작성

