### PR TITLE
[Refactor] 테스트 픽스처 생성 코드 중복 제거

### DIFF
--- a/src/main/java/org/programmers/signalbuddyfinal/domain/like/batch/RequestLikeReader.java
+++ b/src/main/java/org/programmers/signalbuddyfinal/domain/like/batch/RequestLikeReader.java
@@ -35,6 +35,10 @@ public class RequestLikeReader implements ItemStreamReader<LikeUpdateRequest> {
             String key = new String(cursor.next(), StandardCharsets.UTF_8);
             String[] keyInfo = key.split(":");
 
+            if (keyInfo.length < 3) {
+                return null;
+            }
+
             Long feedbackId = Long.parseLong(keyInfo[1]);
             Long memberId = Long.parseLong(keyInfo[2]);
             String likeRequestType = redisTemplate.opsForValue().get(key);

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/comment/repository/CommentRepositoryTest.java
@@ -14,8 +14,7 @@ import org.programmers.signalbuddyfinal.domain.feedback.entity.Feedback;
 import org.programmers.signalbuddyfinal.domain.feedback.entity.enums.FeedbackCategory;
 import org.programmers.signalbuddyfinal.domain.feedback.repository.FeedbackRepository;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
-import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
-import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.support.RepositoryTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,15 +36,14 @@ class CommentRepositoryTest extends RepositoryTest {
     @Autowired
     private CrossroadRepository crossroadRepository;
 
-    private Member member;
+    private Member feedbackWriter;
     private Feedback feedback;
 
     @BeforeEach
     void setup() {
-        member = Member.builder().email("test@test.com").password("123456").role(MemberRole.USER)
-            .nickname("tester").memberStatus(MemberStatus.ACTIVITY)
-            .profileImageUrl("https://test-image.com/test-123131").build();
-        member = memberRepository.save(member);
+        feedbackWriter = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester")
+        );
 
         Crossroad crossroad = Crossroad.create()
             .crossroadApiId("13214").name("00사거리")
@@ -58,7 +56,7 @@ class CommentRepositoryTest extends RepositoryTest {
         Feedback entity = Feedback.create()
             .subject(subject).content(content).secret(Boolean.FALSE)
             .category(FeedbackCategory.ETC)
-            .member(member).crossroad(crossroad)
+            .member(feedbackWriter).crossroad(crossroad)
             .build();
         feedback = feedbackRepository.save(entity);
 
@@ -66,7 +64,7 @@ class CommentRepositoryTest extends RepositoryTest {
         for (int i = 0; i < 30; i++) {
             Comment comment = Comment.create()
                 .content("test comment content")
-                .feedback(feedback).member(member).build();
+                .feedback(feedback).member(feedbackWriter).build();
             commentList.add(comment);
         }
         commentRepository.saveAll(commentList);
@@ -93,7 +91,7 @@ class CommentRepositoryTest extends RepositoryTest {
             softAssertions.assertThat(actual.getContent().get(3).getContent())
                 .isEqualTo("test comment content");
             softAssertions.assertThat(actual.getContent().get(3).getMember().getMemberId())
-                .isEqualTo(member.getMemberId());
+                .isEqualTo(feedbackWriter.getMemberId());
         });
     }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/comment/service/CommentServiceTest.java
@@ -27,6 +27,7 @@ import org.programmers.signalbuddyfinal.domain.feedback.repository.FeedbackRepos
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.domain.notification.dto.FcmMessage;
 import org.programmers.signalbuddyfinal.domain.notification.factory.CommentNotificationFactory;
@@ -57,17 +58,17 @@ class CommentServiceTest extends ServiceTest {
     @Spy
     private CommentNotificationFactory commentNotificationFactory;
 
-    private Member member;
+    private Member feedbackWriter;
     private Member admin;
     private Feedback feedback;
     private Comment comment;
 
     @BeforeEach
     void setup() {
-        member = createMember(1L, "test@test.com", "tester", MemberRole.USER);
-        admin = createMember(7777L, "admin@test.com", "admin", MemberRole.ADMIN);
-        feedback = createFeedback(member);
-        comment = createComment(1L, "test comment content", member, feedback);
+        feedbackWriter = TestMemberFactory.createActiveUser(1L, "test@test.com", "tester");
+        admin = TestMemberFactory.createAdmin(7777L, "admin@test.com", "admin");
+        feedback = createFeedback(feedbackWriter);
+        comment = createComment(1L, "test comment content", feedbackWriter, feedback);
     }
 
     @DisplayName("댓글 작성")
@@ -80,9 +81,8 @@ class CommentServiceTest extends ServiceTest {
             // given
             Long feedbackId = feedback.getFeedbackId();
             CommentRequest request = new CommentRequest("test comment content");
-            Member otherMember = createMember(
-                2L, "other@test.com", "other tester",
-                MemberRole.USER
+            Member otherMember = TestMemberFactory.createActiveUser(
+                2L, "other@test.com", "other tester"
             );
             CustomUser2Member requestUser = createCurrentMember(
                 otherMember.getMemberId(), MemberRole.USER
@@ -113,14 +113,14 @@ class CommentServiceTest extends ServiceTest {
             Long feedbackId = feedback.getFeedbackId();
             String content = "test comment content";
             CommentRequest request = new CommentRequest(content);
-            CustomUser2Member requestUser = createCurrentMember(member.getMemberId(), MemberRole.USER);
+            CustomUser2Member requestUser = createCurrentMember(feedbackWriter.getMemberId(), MemberRole.USER);
 
             given(memberRepository.findByIdOrThrow(requestUser.getMemberId()))
-                .willReturn(member);
+                .willReturn(feedbackWriter);
             given(feedbackRepository.findByIdOrThrow(feedbackId))
                 .willReturn(feedback);
             given(commentRepository.save(any(Comment.class)))
-                .willReturn(createComment(2L, request.getContent(), member, feedback));
+                .willReturn(createComment(2L, request.getContent(), feedbackWriter, feedback));
             doNothing().when(fcmService).sendMessage(any(FcmMessage.class), anyLong());
 
             // when
@@ -140,11 +140,10 @@ class CommentServiceTest extends ServiceTest {
             Long feedbackId = feedback.getFeedbackId();
             String content = "test comment content";
             CommentRequest request = new CommentRequest(content);
-            Member otherMember = createMember(
-                2L, "other@test.com", "other tester",
-                MemberRole.USER
+            Member otherMember = TestMemberFactory.createActiveUser(
+                2L, "other@test.com", "other tester"
             );
-            member.updateNotifyEnabled(Boolean.FALSE);
+            feedbackWriter.updateNotifyEnabled(Boolean.FALSE);
             CustomUser2Member requestUser = createCurrentMember(
                 otherMember.getMemberId(), MemberRole.USER
             );
@@ -206,7 +205,7 @@ class CommentServiceTest extends ServiceTest {
             // given
             String updatedContent = "update comment content";
             CommentRequest request = new CommentRequest(updatedContent);
-            CustomUser2Member requestUser = createCurrentMember(member.getMemberId(), MemberRole.USER);
+            CustomUser2Member requestUser = createCurrentMember(feedbackWriter.getMemberId(), MemberRole.USER);
 
             given(commentRepository.findByIdOrThrow(requestUser.getMemberId()))
                 .willReturn(comment);
@@ -224,9 +223,8 @@ class CommentServiceTest extends ServiceTest {
             // given
             String updatedContent = "update comment content";
             CommentRequest request = new CommentRequest(updatedContent);
-            Member otherMember = createMember(
-                2L, "other@test.com", "other tester",
-                MemberRole.USER
+            Member otherMember = TestMemberFactory.createActiveUser(
+                2L, "other@test.com", "other tester"
             );
             CustomUser2Member requestUser = createCurrentMember(
                 otherMember.getMemberId(), MemberRole.USER
@@ -254,7 +252,7 @@ class CommentServiceTest extends ServiceTest {
         void deleteComment() {
             // given
             Long commentId = comment.getCommentId();
-            CustomUser2Member requestUser = createCurrentMember(member.getMemberId(), MemberRole.USER);
+            CustomUser2Member requestUser = createCurrentMember(feedbackWriter.getMemberId(), MemberRole.USER);
 
             given(commentRepository.findByIdOrThrow(commentId))
                 .willReturn(comment);
@@ -325,14 +323,6 @@ class CommentServiceTest extends ServiceTest {
             assertThat(feedback.getAnswerStatus())
                 .isEqualTo(AnswerStatus.BEFORE);
         }
-    }
-
-    private Member createMember(Long id, String email, String nickname, MemberRole role) {
-        return Member.builder()
-            .memberId(id).email(email).password("123456").role(role)
-            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-            .profileImageUrl("https://test-image.com/test-123131")
-            .build();
     }
 
     private Crossroad createCrossroad() {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback/repository/FeedbackRepositoryImplTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback/repository/FeedbackRepositoryImplTest.java
@@ -20,8 +20,8 @@ import org.programmers.signalbuddyfinal.domain.feedback.entity.enums.AnswerStatu
 import org.programmers.signalbuddyfinal.domain.feedback.entity.enums.FeedbackCategory;
 import org.programmers.signalbuddyfinal.domain.feedback.exception.FeedbackErrorCode;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
-import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.constant.SearchTarget;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
@@ -48,19 +48,23 @@ class FeedbackRepositoryImplTest extends RepositoryTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
-    private Member member;
-    private Member withDrawalMember;
+    private Member feedbackWriter;
+    private Member withdrawalFeedbackWriter;
 
     @BeforeEach
     void setup() {
-        member = saveMember("test@test.com", "tester");
-        withDrawalMember = saveWithDrawalMember("with@test.com", "withdrawal");
+        feedbackWriter = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester")
+        );
+        withdrawalFeedbackWriter = memberRepository.save(
+            TestMemberFactory.createWithdrawalUser("with@test.com", "withdrawal")
+        );
         Crossroad crossroad = saveCrossroad("13214", "00사거리", 37.12222, 127.12132);
 
-        saveFeedback("test subject", "test content", member, crossroad);
-        saveFeedback("test subject2", "test content2", withDrawalMember, crossroad);
-        saveFeedback("test subject3", "test content3", member, crossroad);
-        saveFeedback("test subject4", "test content4", member, crossroad);
+        saveFeedback("test subject", "test content", feedbackWriter, crossroad);
+        saveFeedback("test subject2", "test content2", withdrawalFeedbackWriter, crossroad);
+        saveFeedback("test subject3", "test content3", feedbackWriter, crossroad);
+        saveFeedback("test subject4", "test content4", feedbackWriter, crossroad);
 
         createFulltextIndexOnMember();
         createFulltextIndexOnFeedback();
@@ -69,13 +73,16 @@ class FeedbackRepositoryImplTest extends RepositoryTest {
     @DisplayName("활동 중인 회원들의 피드백 목록을 조회한다.")
     @Test
     void getFeedbacks() {
+        // Given
         FeedbackSearchCondition searchCondition = FeedbackSearchCondition.builder()
             .target(SearchTarget.SUBJECT_OR_CONTENT).answerStatus(AnswerStatus.BEFORE)
             .build();
 
+        // When
         Page<FeedbackResponse> allByActiveMembers = feedbackRepository.findAllByActiveMembers(
             Pageable.ofSize(10), null, searchCondition);
 
+        // Then
         assertThat(allByActiveMembers).isNotNull();
         assertThat(allByActiveMembers.getTotalElements()).isEqualTo(3);
         assertThat(allByActiveMembers.getTotalPages()).isEqualTo(1);
@@ -93,9 +100,9 @@ class FeedbackRepositoryImplTest extends RepositoryTest {
         String subject = "test subject";
         String content = "test content";
         for (int i = 10; i < 13; i++) {
-            saveFeedback(subject + i, content + i, member, crossroad);
+            saveFeedback(subject + i, content + i, feedbackWriter, crossroad);
         }
-        saveFeedback(subject + 13, content + 13, withDrawalMember, crossroad);
+        saveFeedback(subject + 13, content + 13, withdrawalFeedbackWriter, crossroad);
 
         createFulltextIndexOnFeedback();
 
@@ -128,10 +135,11 @@ class FeedbackRepositoryImplTest extends RepositoryTest {
         // Given
         Set<FeedbackCategory> categories = Set.of(FeedbackCategory.DELAY, FeedbackCategory.ADD_SIGNAL);
         Crossroad crossroad = saveCrossroad("114111", "00삼거리", 37.42222, 127.42132);
-        saveFeedback("test subject11", "test content11", FeedbackCategory.DELAY, member, crossroad);
-        saveFeedback("test subject12", "test content12", FeedbackCategory.DELAY, member, crossroad);
-        saveFeedback("test subject13", "test content13", FeedbackCategory.ADD_SIGNAL, member, crossroad);
-        saveFeedback("test subject14", "test content14", member, crossroad);
+        saveFeedback("test subject11", "test content11", FeedbackCategory.DELAY, feedbackWriter, crossroad);
+        saveFeedback("test subject12", "test content12", FeedbackCategory.DELAY, feedbackWriter, crossroad);
+        saveFeedback("test subject13", "test content13", FeedbackCategory.ADD_SIGNAL,
+            feedbackWriter, crossroad);
+        saveFeedback("test subject14", "test content14", feedbackWriter, crossroad);
 
         createFulltextIndexOnFeedback();
 
@@ -168,10 +176,11 @@ class FeedbackRepositoryImplTest extends RepositoryTest {
         String keyword = "홍길동";
         Set<FeedbackCategory> categories = Set.of(FeedbackCategory.DELAY, FeedbackCategory.ADD_SIGNAL);
         Crossroad crossroad = saveCrossroad("114111", "00삼거리", 37.42222, 127.42132);
-        saveFeedback("ㅁㅁㅁ " + keyword, "test content11", FeedbackCategory.DELAY, member, crossroad);
-        saveFeedback("test subject12", "test content12", FeedbackCategory.DELAY, member, crossroad);
-        saveFeedback("test subject13", keyword + " ㅁㅁㅁ", FeedbackCategory.ADD_SIGNAL, member, crossroad);
-        saveFeedback("test subject14", "test content14", member, crossroad);
+        saveFeedback("ㅁㅁㅁ " + keyword, "test content11", FeedbackCategory.DELAY, feedbackWriter, crossroad);
+        saveFeedback("test subject12", "test content12", FeedbackCategory.DELAY, feedbackWriter, crossroad);
+        saveFeedback("test subject13", keyword + " ㅁㅁㅁ", FeedbackCategory.ADD_SIGNAL,
+            feedbackWriter, crossroad);
+        saveFeedback("test subject14", "test content14", feedbackWriter, crossroad);
 
         createFulltextIndexOnFeedback();
 
@@ -205,7 +214,7 @@ class FeedbackRepositoryImplTest extends RepositoryTest {
     @Test
     void findAllByActiveMembersByKeywordFromWriter() {
         // Given
-        String keyword = member.getNickname();
+        String keyword = feedbackWriter.getNickname();
 
         FeedbackSearchCondition searchCondition = FeedbackSearchCondition.builder()
             .target(SearchTarget.WRITER).keyword(keyword)
@@ -307,20 +316,6 @@ class FeedbackRepositoryImplTest extends RepositoryTest {
         } catch (BusinessException e) {
             assertThat(e.getErrorCode()).isEqualTo(FeedbackErrorCode.NOT_FOUND_FEEDBACK);
         }
-    }
-
-    private Member saveMember(String email, String nickname) {
-        return memberRepository.save(
-            Member.builder().email(email).password("123456").role(MemberRole.USER)
-                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131").build());
-    }
-
-    private Member saveWithDrawalMember(String email, String nickname) {
-        return memberRepository.save(
-            Member.builder().email(email).password("123456").role(MemberRole.USER)
-                .nickname(nickname).memberStatus(MemberStatus.WITHDRAWAL)
-                .profileImageUrl("https://test-image.com/test-123131").build());
     }
 
     private Crossroad saveCrossroad(String apiId, String name, double lat, double lng) {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback/service/FeedbackServiceTest.java
@@ -28,6 +28,7 @@ import org.programmers.signalbuddyfinal.domain.like.repository.LikeRepository;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
 import org.programmers.signalbuddyfinal.global.dto.PageResponse;
@@ -60,19 +61,21 @@ class FeedbackServiceTest extends IntegrationTest {
     @MockitoBean
     private AwsFileService awsFileService;
 
-    private Member member;
+    private Member feedbackWriter;
     private Crossroad crossroad;
     private final String imageFormName = "imageFile";
 
     @BeforeEach
     void setup() {
-        member = saveMember("test@test.com", "tester");
+        feedbackWriter = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester")
+        );
         crossroad = saveCrossroad("13214", "00사거리", 37.12222, 127.12132);
 
-        saveFeedback("test subject", "test content", member, crossroad);
-        saveFeedback("test subject2", "test content2", member, crossroad);
-        saveFeedback("test subject3", "test content3", member, crossroad);
-        saveSoftDeleteFeedback("test subject4", "test content4", member, crossroad);
+        saveFeedback("test subject", "test content", feedbackWriter, crossroad);
+        saveFeedback("test subject2", "test content2", feedbackWriter, crossroad);
+        saveFeedback("test subject3", "test content3", feedbackWriter, crossroad);
+        saveSoftDeleteFeedback("test subject4", "test content4", feedbackWriter, crossroad);
     }
 
     @DisplayName("피드백을 작성한다.")
@@ -87,7 +90,7 @@ class FeedbackServiceTest extends IntegrationTest {
             .category(FeedbackCategory.ETC).crossroadId(crossroadId)
             .build();
         MockMultipartFile imageFile = getMockImageFile(imageFormName);
-        CustomUser2Member user = getCurrentMember(member.getMemberId(), MemberRole.USER);
+        CustomUser2Member user = getCurrentMember(feedbackWriter.getMemberId(), MemberRole.USER);
 
         // When
         URL mockURL = mock(URL.class);
@@ -113,7 +116,7 @@ class FeedbackServiceTest extends IntegrationTest {
     void getFeedbacksByMember() {
         // feedbackNoMemberDto
         final PageResponse<FeedbackResponse> feedbacks = feedbackService.findPagedExcludingMember(
-            member.getMemberId(), Pageable.ofSize(10));
+            feedbackWriter.getMemberId(), Pageable.ofSize(10));
 
         assertThat(feedbacks).isNotNull();
         assertThat(feedbacks.getTotalElements()).isEqualTo(3);
@@ -136,7 +139,7 @@ class FeedbackServiceTest extends IntegrationTest {
         SoftAssertions.assertSoftly(softAssertions -> {
             assertThat(response.getFeedbackId()).isEqualTo(feedbackId);
             assertThat(response.getMember().getMemberId())
-                .isEqualTo(member.getMemberId());
+                .isEqualTo(feedbackWriter.getMemberId());
             assertThat(response.getCrossroad().getCrossroadId())
                 .isEqualTo(crossroad.getCrossroadId());
         });
@@ -147,9 +150,9 @@ class FeedbackServiceTest extends IntegrationTest {
     void searchSecretFeedbackDetail_Success() {
         // Given
         Feedback secret = saveSecretFeedback(
-            "test subject5", "test content5", member, crossroad
+            "test subject5", "test content5", feedbackWriter, crossroad
         );
-        CustomUser2Member user = getCurrentMember(member.getMemberId(), MemberRole.USER);
+        CustomUser2Member user = getCurrentMember(feedbackWriter.getMemberId(), MemberRole.USER);
 
         // When
         FeedbackResponse response = feedbackService.searchFeedbackDetail(
@@ -161,7 +164,7 @@ class FeedbackServiceTest extends IntegrationTest {
             assertThat(response.getFeedbackId()).isEqualTo(secret.getFeedbackId());
             assertThat(response.getSecret()).isTrue();
             assertThat(response.getMember().getMemberId())
-                .isEqualTo(member.getMemberId());
+                .isEqualTo(feedbackWriter.getMemberId());
             assertThat(response.getCrossroad().getCrossroadId())
                 .isEqualTo(crossroad.getCrossroadId());
         });
@@ -172,9 +175,11 @@ class FeedbackServiceTest extends IntegrationTest {
     void searchSecretFeedbackDetail_Failure() {
         // Given
         Feedback secret = saveSecretFeedback(
-            "test subject5", "test content5", member, crossroad
+            "test subject5", "test content5", feedbackWriter, crossroad
         );
-        Member otherMember = saveMember("test2@test.com", "tester2");
+        Member otherMember = memberRepository.save(
+            TestMemberFactory.createActiveUser("test2@test.com", "tester2")
+        );
         CustomUser2Member user = getCurrentMember(otherMember.getMemberId(), MemberRole.USER);
 
         // When & Then
@@ -191,9 +196,11 @@ class FeedbackServiceTest extends IntegrationTest {
     void searchSecretFeedbackDetailByAdmin_Success() {
         // Given
         Feedback secret = saveSecretFeedback(
-            "test subject5", "test content5", member, crossroad
+            "test subject5", "test content5", feedbackWriter, crossroad
         );
-        Member admin = saveAdmin("test@test.com", "tester2");
+        Member admin = memberRepository.save(
+            TestMemberFactory.createAdmin("test@test.com", "tester2")
+        );
         CustomUser2Member user = getCurrentMember(admin.getMemberId(), MemberRole.ADMIN);
 
         // When
@@ -206,7 +213,7 @@ class FeedbackServiceTest extends IntegrationTest {
             assertThat(response.getFeedbackId()).isEqualTo(secret.getFeedbackId());
             assertThat(response.getSecret()).isTrue();
             assertThat(response.getMember().getMemberId())
-                .isEqualTo(member.getMemberId());
+                .isEqualTo(feedbackWriter.getMemberId());
             assertThat(response.getMember().getMemberId())
                 .isNotEqualTo(user.getMemberId());
             assertThat(response.getCrossroad().getCrossroadId())
@@ -219,7 +226,7 @@ class FeedbackServiceTest extends IntegrationTest {
     void updateFeedback() {
         // Given
         Feedback feedback = saveFeedback(
-            "test subject", "test content", member, crossroad
+            "test subject", "test content", feedbackWriter, crossroad
         );
         Long feedbackId = feedback.getFeedbackId();
         FeedbackCategory updatedCategory = FeedbackCategory.DELAY;
@@ -229,7 +236,7 @@ class FeedbackServiceTest extends IntegrationTest {
             .category(updatedCategory).crossroadId(crossroad.getCrossroadId())
             .build();
         MockMultipartFile updatedImageFile = getMockImageFile(imageFormName);
-        CustomUser2Member user = getCurrentMember(member.getMemberId(), MemberRole.USER);
+        CustomUser2Member user = getCurrentMember(feedbackWriter.getMemberId(), MemberRole.USER);
 
         // When
         URL mockURL = mock(URL.class);
@@ -254,7 +261,7 @@ class FeedbackServiceTest extends IntegrationTest {
     void updateFeedback_DeleteImage() {
         // Given
         Feedback feedback = saveFeedback(
-            "test subject", "test content", member, crossroad
+            "test subject", "test content", feedbackWriter, crossroad
         );
         Long feedbackId = feedback.getFeedbackId();
         FeedbackCategory updatedCategory = FeedbackCategory.DELAY;
@@ -264,7 +271,7 @@ class FeedbackServiceTest extends IntegrationTest {
             .category(updatedCategory).crossroadId(crossroad.getCrossroadId())
             .build();
         MockMultipartFile updatedImageFile = null;
-        CustomUser2Member user = getCurrentMember(member.getMemberId(), MemberRole.USER);
+        CustomUser2Member user = getCurrentMember(feedbackWriter.getMemberId(), MemberRole.USER);
 
         // When
         FeedbackResponse actual = feedbackService.updateFeedback(
@@ -286,7 +293,9 @@ class FeedbackServiceTest extends IntegrationTest {
             .subject("updated").content("aaaa").crossroadId(1L)
             .category(FeedbackCategory.ETC).secret(Boolean.FALSE)
             .build();
-        Member otherMember = saveMember("test@test.com", "tester2");
+        Member otherMember = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester2")
+        );
         CustomUser2Member user = getCurrentMember(otherMember.getMemberId(), MemberRole.USER);
 
         // When & Then
@@ -303,7 +312,7 @@ class FeedbackServiceTest extends IntegrationTest {
     void deleteFeedback_Success() {
         // Given
         Long feedbackId = 2L;
-        CustomUser2Member user = getCurrentMember(member.getMemberId(), MemberRole.USER);
+        CustomUser2Member user = getCurrentMember(feedbackWriter.getMemberId(), MemberRole.USER);
 
         // When
         feedbackService.deleteFeedback(feedbackId, user);
@@ -317,7 +326,9 @@ class FeedbackServiceTest extends IntegrationTest {
     void deleteFeedback_Failure() {
         // Given
         Long feedbackId = 2L;
-        Member otherMember = saveMember("test@test.com", "tester2");
+        Member otherMember = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester2")
+        );
         CustomUser2Member user = getCurrentMember(otherMember.getMemberId(), MemberRole.USER);
 
         // When & Then
@@ -334,7 +345,9 @@ class FeedbackServiceTest extends IntegrationTest {
     void deleteFeedbackByAdmin() {
         // Given
         Long feedbackId = 2L;
-        Member admin = saveAdmin("test@test.com", "tester2");
+        Member admin = memberRepository.save(
+            TestMemberFactory.createAdmin("test@test.com", "tester2")
+        );
         CustomUser2Member user = getCurrentMember(admin.getMemberId(), MemberRole.ADMIN);
 
         // When
@@ -350,7 +363,9 @@ class FeedbackServiceTest extends IntegrationTest {
         final List<Feedback> feedbacks = feedbackRepository.findAll().stream()
             .filter(feedback -> !feedback.isDeleted())
             .toList();
-        final Member likedUser = saveMember("test2@test.com", "tester2");
+        final Member likedUser = memberRepository.save(
+            TestMemberFactory.createActiveUser("test2@test.com", "tester2")
+        );
 
         final List<Like> likes = List.of(
             Like.create(likedUser, feedbacks.get(0)),
@@ -363,22 +378,8 @@ class FeedbackServiceTest extends IntegrationTest {
         assertThat(feedbacks).hasSize(3);
         assertThat(likedFeedbacks.getTotalElements()).isEqualTo(2);
         assertThat(likedFeedbacks.getSearchResults()).allSatisfy(feedback -> {
-            assertThat(feedback.getMember().getMemberId()).isEqualTo(member.getMemberId());
+            assertThat(feedback.getMember().getMemberId()).isEqualTo(feedbackWriter.getMemberId());
         });
-    }
-
-    private Member saveMember(String email, String nickname) {
-        return memberRepository.save(
-            Member.builder().email(email).password("123456").role(MemberRole.USER)
-                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131").build());
-    }
-
-    private Member saveAdmin(String email, String nickname) {
-        return memberRepository.save(
-            Member.builder().email(email).password("123456").role(MemberRole.ADMIN)
-                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131").build());
     }
 
     private Crossroad saveCrossroad(String apiId, String name, double lat, double lng) {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_report/repository/FeedbackReportRepositoryTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_report/repository/FeedbackReportRepositoryTest.java
@@ -20,8 +20,7 @@ import org.programmers.signalbuddyfinal.domain.feedback_report.entity.FeedbackRe
 import org.programmers.signalbuddyfinal.domain.feedback_report.entity.enums.FeedbackReportCategory;
 import org.programmers.signalbuddyfinal.domain.feedback_report.entity.enums.FeedbackReportStatus;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
-import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
-import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.constant.SearchTarget;
 import org.programmers.signalbuddyfinal.global.support.RepositoryTest;
@@ -50,17 +49,19 @@ class FeedbackReportRepositoryTest extends RepositoryTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
-    private Member member;
+    private Member feedbackWriter;
     private Feedback feedback;
 
     @BeforeEach
     void setup() {
-        member = saveMember("test@test.com", "tester");
+        feedbackWriter = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester")
+        );
         Crossroad crossroad = saveCrossroad("12313", "00 사거리", 37.12, 127.12);
-        feedback = saveFeedback("test", "test", member, crossroad);
+        feedback = saveFeedback("test", "test", feedbackWriter, crossroad);
 
         for (int i = 1; i <= 12; i++) {
-            saveFeedbackReport("test " + i, member, feedback);
+            saveFeedbackReport("test " + i, feedbackWriter, feedback);
         }
 
         createFulltextIndexOnMember();
@@ -100,7 +101,7 @@ class FeedbackReportRepositoryTest extends RepositoryTest {
         // Given
         Pageable pageable = PageRequest.of(0, 7,
             Direction.DESC, "createdAt");
-        String keyword = member.getNickname();
+        String keyword = feedbackWriter.getNickname();
 
         // When
         Page<FeedbackReportResponse> actual = reportRepository.findAllByFilter(
@@ -131,11 +132,11 @@ class FeedbackReportRepositoryTest extends RepositoryTest {
         String keyword = "test";
 
         FeedbackReport feedbackReport1 = saveFeedbackReport(
-            "test 13", FeedbackReportCategory.FALSE, member, feedback
+            "test 13", FeedbackReportCategory.FALSE, feedbackWriter, feedback
         );
         feedbackReport1.updateStatus(FeedbackReportStatus.REJECTED);
         FeedbackReport feedbackReport2 = saveFeedbackReport(
-            "test 14", FeedbackReportCategory.OFFENSIVE, member, feedback
+            "test 14", FeedbackReportCategory.OFFENSIVE, feedbackWriter, feedback
         );
         feedbackReport2.updateStatus(FeedbackReportStatus.PROCESSED);
         reportRepository.save(feedbackReport1);
@@ -194,13 +195,6 @@ class FeedbackReportRepositoryTest extends RepositoryTest {
                 pageable, SearchTarget.SUBJECT_OR_CONTENT, keyword,
                 Collections.emptySet(), null, startDate, endDate
             );
-    }
-
-    private Member saveMember(String email, String nickname) {
-        return memberRepository.save(
-            Member.builder().email(email).password("123456").role(MemberRole.USER)
-                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131").build());
     }
 
     private Crossroad saveCrossroad(String apiId, String name, double lat, double lng) {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_report/service/FeedbackReportServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_report/service/FeedbackReportServiceTest.java
@@ -22,6 +22,7 @@ import org.programmers.signalbuddyfinal.domain.feedback_report.repository.Feedba
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
 import org.programmers.signalbuddyfinal.global.exception.BusinessException;
@@ -46,16 +47,20 @@ class FeedbackReportServiceTest extends IntegrationTest {
     @Autowired
     private CrossroadRepository crossroadRepository;
 
-    private Member member;
+    private Member feedbackWriter;
     private Member admin;
     private Feedback feedback;
 
     @BeforeEach
     void setup() {
-        admin = saveAdmin("admin@test.com", "admin");
-        member = saveMember("test@test.com", "tester");
+        admin = memberRepository.save(
+            TestMemberFactory.createAdmin("admin@test.com", "admin")
+        );
+        feedbackWriter = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester")
+        );
         Crossroad crossroad = saveCrossroad("12313", "00 사거리", 37.12, 127.12);
-        feedback = saveFeedback("test", "test", member, crossroad);
+        feedback = saveFeedback("test", "test", feedbackWriter, crossroad);
     }
 
     @DisplayName("피드백 신고를 작성한다.")
@@ -67,7 +72,9 @@ class FeedbackReportServiceTest extends IntegrationTest {
         FeedbackReportRequest request = FeedbackReportRequest.builder()
             .content(content).category(FeedbackReportCategory.ETC)
             .build();
-        Member requestMember = saveMember("request@test.com", "request");
+        Member requestMember = memberRepository.save(
+            TestMemberFactory.createActiveUser("request@test.com", "request")
+        );
         CustomUser2Member user = getCurrentMember(requestMember.getMemberId(), MemberRole.USER);
 
         // When
@@ -88,7 +95,7 @@ class FeedbackReportServiceTest extends IntegrationTest {
     void updateFeedbackReportByAdmin_Success() {
         // Given
         Long feedbackId = feedback.getFeedbackId();
-        FeedbackReport report = saveFeedbackReport("test", member, feedback);
+        FeedbackReport report = saveFeedbackReport("test", feedbackWriter, feedback);
         Long reportId = report.getFeedbackReportId();
 
         FeedbackReportUpdateRequest request = FeedbackReportUpdateRequest.builder()
@@ -113,7 +120,7 @@ class FeedbackReportServiceTest extends IntegrationTest {
     void deleteFeedbackReportByAdmin_Success() {
         // Given
         Long feedbackId = feedback.getFeedbackId();
-        FeedbackReport report = saveFeedbackReport("test", member, feedback);
+        FeedbackReport report = saveFeedbackReport("test", feedbackWriter, feedback);
         CustomUser2Member user = getCurrentMember(admin.getMemberId(), MemberRole.ADMIN);
 
         // When
@@ -128,8 +135,8 @@ class FeedbackReportServiceTest extends IntegrationTest {
     void deleteFeedbackReportByUser_Failure() {
         // Given
         Long feedbackId = feedback.getFeedbackId();
-        FeedbackReport report = saveFeedbackReport("test", member, feedback);
-        CustomUser2Member user = getCurrentMember(member.getMemberId(), MemberRole.USER);
+        FeedbackReport report = saveFeedbackReport("test", feedbackWriter, feedback);
+        CustomUser2Member user = getCurrentMember(feedbackWriter.getMemberId(), MemberRole.USER);
 
         // When & Then
         try {
@@ -145,7 +152,7 @@ class FeedbackReportServiceTest extends IntegrationTest {
     void deleteFeedbackReport_Failure() {
         // Given
         Long feedbackId = 99999999999L;
-        FeedbackReport report = saveFeedbackReport("test", member, feedback);
+        FeedbackReport report = saveFeedbackReport("test", feedbackWriter, feedback);
         CustomUser2Member user = getCurrentMember(admin.getMemberId(), MemberRole.ADMIN);
 
         // When & Then
@@ -155,20 +162,6 @@ class FeedbackReportServiceTest extends IntegrationTest {
             assertThat(e.getErrorCode())
                 .isEqualTo(FeedbackReportErrorCode.FEEDBACK_REPORT_MISMATCH);
         }
-    }
-
-    private Member saveMember(String email, String nickname) {
-        return memberRepository.save(
-            Member.builder().email(email).password("123456").role(MemberRole.USER)
-                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131").build());
-    }
-
-    private Member saveAdmin(String email, String nickname) {
-        return memberRepository.save(
-            Member.builder().email(email).password("123456").role(MemberRole.ADMIN)
-                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131").build());
     }
 
     private Crossroad saveCrossroad(String apiId, String name, double lat, double lng) {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_summary/batch/FeedbackSummaryTaskletTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_summary/batch/FeedbackSummaryTaskletTest.java
@@ -15,8 +15,7 @@ import org.programmers.signalbuddyfinal.domain.feedback.repository.FeedbackRepos
 import org.programmers.signalbuddyfinal.domain.feedback_summary.entity.FeedbackSummary;
 import org.programmers.signalbuddyfinal.domain.feedback_summary.repository.FeedbackSummaryRepository;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
-import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
-import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.support.BatchTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +39,9 @@ class FeedbackSummaryTaskletTest extends BatchTest {
 
     @BeforeEach
     void setUp() {
-        Member member = saveMember("test@test.com", "tester");
+        Member feedbackWriter = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester")
+        );
         Crossroad crossroad1 = saveCrossroad("1321", "00 사거리", 37.12123, 127.1231);
         Crossroad crossroad2 = saveCrossroad("132122", "001 사거리", 37.121123, 127.1251);
         Crossroad crossroad3 = saveCrossroad("133321", "002 사거리", 37.12323, 127.1221);
@@ -49,7 +50,7 @@ class FeedbackSummaryTaskletTest extends BatchTest {
             if (i == 1) {
                 saveFeedback(
                     "subject " + i, "content " + i, FeedbackCategory.ETC,
-                    member, crossroad3
+                    feedbackWriter, crossroad3
                 );
                 continue;
             }
@@ -57,14 +58,14 @@ class FeedbackSummaryTaskletTest extends BatchTest {
             if (i % 3 == 0) {
                 saveFeedback(
                     "subject " + i, "content " + i, FeedbackCategory.DELAY,
-                    member, crossroad1
+                    feedbackWriter, crossroad1
                 );
             }
 
             if (i % 2 == 0) {
                 saveFeedback(
                     "subject " + i, "content " + i, FeedbackCategory.ADD_SIGNAL,
-                    member, crossroad2
+                    feedbackWriter, crossroad2
                 );
             }
         }
@@ -91,13 +92,6 @@ class FeedbackSummaryTaskletTest extends BatchTest {
             softAssertions.assertThat(feedbackSummary.getCrossroadRanks().get(1).getCount())
                 .isEqualTo(2L);
         });
-    }
-
-    private Member saveMember(String email, String nickname) {
-        return memberRepository.saveAndFlush(
-            Member.builder().email(email).password("123456").role(MemberRole.USER)
-                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131").build());
     }
 
     private Crossroad saveCrossroad(String apiId, String name, double lat, double lng) {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_summary/repository/CustomFeedbackSummaryRepositoryImplTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_summary/repository/CustomFeedbackSummaryRepositoryImplTest.java
@@ -16,8 +16,7 @@ import org.programmers.signalbuddyfinal.domain.feedback.repository.FeedbackRepos
 import org.programmers.signalbuddyfinal.domain.feedback_summary.entity.CrossroadFeedbackCount;
 import org.programmers.signalbuddyfinal.domain.feedback_summary.entity.FeedbackCategoryCount;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
-import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
-import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.support.IntegrationTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +39,9 @@ class CustomFeedbackSummaryRepositoryImplTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        Member member = saveMember("test@test.com", "tester");
+        Member feedbackWriter = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester")
+        );
         Crossroad crossroad1 = saveCrossroad("1321", "00 사거리", 37.12123, 127.1231);
         Crossroad crossroad2 = saveCrossroad("132122", "001 사거리", 37.121123, 127.1251);
         Crossroad crossroad3 = saveCrossroad("133321", "002 사거리", 37.12323, 127.1221);
@@ -49,7 +50,7 @@ class CustomFeedbackSummaryRepositoryImplTest extends IntegrationTest {
             if (i == 1) {
                 saveFeedback(
                     "subject " + i, "content " + i, FeedbackCategory.ETC,
-                    member, crossroad3
+                    feedbackWriter, crossroad3
                 );
                 continue;
             }
@@ -57,21 +58,21 @@ class CustomFeedbackSummaryRepositoryImplTest extends IntegrationTest {
             if (i % 3 == 0) {
                 saveFeedback(
                     "subject " + i, "content " + i, FeedbackCategory.DELAY,
-                    member, crossroad1
+                    feedbackWriter, crossroad1
                 );
             }
 
             if (i % 2 == 0) {
                 saveFeedback(
                     "subject " + i, "content " + i, FeedbackCategory.ADD_SIGNAL,
-                    member, crossroad2
+                    feedbackWriter, crossroad2
                 );
             }
         }
 
         saveDeletedFeedback(
             "deleted subject ", "deleted content ",
-            FeedbackCategory.DELAY, member, crossroad1
+            FeedbackCategory.DELAY, feedbackWriter, crossroad1
         );
     }
 
@@ -118,13 +119,6 @@ class CustomFeedbackSummaryRepositoryImplTest extends IntegrationTest {
             feedbackSummaryRepository.countFeedbackByDate(LocalDate.now())
         ).isEqualTo(6L);
 
-    }
-
-    private Member saveMember(String email, String nickname) {
-        return memberRepository.saveAndFlush(
-            Member.builder().email(email).password("123456").role(MemberRole.USER)
-                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131").build());
     }
 
     private Crossroad saveCrossroad(String apiId, String name, double lat, double lng) {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_summary/service/FeedbackSummaryServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_summary/service/FeedbackSummaryServiceTest.java
@@ -26,7 +26,7 @@ class FeedbackSummaryServiceTest extends IntegrationTest {
     @MockitoBean
     private FeedbackSummaryRepository feedbackSummaryRepository;
 
-    @DisplayName("")
+    @DisplayName("피드백 집계 데이터를 가져온다.")
     @Test
     void getFeedbackSummary() {
         // Given

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/like/batch/LikeJobConfigTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/like/batch/LikeJobConfigTest.java
@@ -18,6 +18,7 @@ import org.programmers.signalbuddyfinal.domain.like.service.LikeService;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.db.RedisTestContainer;
 import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
@@ -55,15 +56,9 @@ class LikeJobConfigTest extends BatchTest implements RedisTestContainer {
     void setup() {
         List<Member> memberList = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
-            Member member = Member.builder()
-                .email("test@test.com")
-                .password("123456" + i)
-                .role(MemberRole.USER)
-                .nickname("tester")
-                .memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131")
-                .build();
-            memberList.add(member);
+            memberList.add(
+                TestMemberFactory.createActiveUser("test" + i + "@test.com", "tester" + i)
+            );
         }
         savedMemberList = memberRepository.saveAll(memberList);
     }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/like/service/LikeServiceTest.java
@@ -19,6 +19,7 @@ import org.programmers.signalbuddyfinal.domain.like.repository.LikeRepository;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.global.db.RedisTestContainer;
 import org.programmers.signalbuddyfinal.global.dto.CustomUser2Member;
@@ -49,20 +50,14 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
     @Autowired
     private StringRedisTemplate redisTemplate;
 
-    private Member member;
+    private Member feedbackWriter;
     private Feedback feedback;
 
     @BeforeEach
     void setup() {
-        member = Member.builder()
-            .email("test@test.com")
-            .password("123456")
-            .role(MemberRole.USER)
-            .nickname("tester")
-            .memberStatus(MemberStatus.ACTIVITY)
-            .profileImageUrl("https://test-image.com/test-123131")
-            .build();
-        member = memberRepository.save(member);
+        feedbackWriter = memberRepository.save(
+            TestMemberFactory.createActiveUser("test@test.com", "tester")
+        );
 
         Crossroad crossroad = Crossroad.create()
             .crossroadApiId("13214").name("00사거리")
@@ -75,7 +70,7 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
         Feedback entity = Feedback.create()
             .subject(subject).content(content).secret(Boolean.FALSE)
             .category(FeedbackCategory.ETC)
-            .member(member).crossroad(crossroad)
+            .member(feedbackWriter).crossroad(crossroad)
             .build();
         feedback = feedbackRepository.save(entity);
     }
@@ -93,7 +88,7 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
     void addLike_Success() {
         // given
         CustomUser2Member user = new CustomUser2Member(
-            new CustomUserDetails(member.getMemberId(), "", "",
+            new CustomUserDetails(feedbackWriter.getMemberId(), "", "",
                 "", "", MemberRole.USER, MemberStatus.ACTIVITY));
 
         // when
@@ -101,10 +96,10 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
 
         // then
         String deleteLike = redisTemplate.opsForValue()
-            .get(generateKey(feedback.getFeedbackId(), member.getMemberId()));
+            .get(generateKey(feedback.getFeedbackId(), feedbackWriter.getMemberId()));
         assertThat(deleteLike).isEqualTo("ADD");
         redisTemplate.delete(
-            generateKey(feedback.getFeedbackId(), member.getMemberId())
+            generateKey(feedback.getFeedbackId(), feedbackWriter.getMemberId())
         );
     }
 
@@ -113,10 +108,10 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
     void addLike_Failure() {
         // given
         CustomUser2Member user = new CustomUser2Member(
-            new CustomUserDetails(member.getMemberId(), "", "",
+            new CustomUserDetails(feedbackWriter.getMemberId(), "", "",
                 "", "", MemberRole.USER, MemberStatus.ACTIVITY));
 
-        likeRepository.save(Like.create(member, feedback));
+        likeRepository.save(Like.create(feedbackWriter, feedback));
 
         // when & then
         try {
@@ -131,20 +126,20 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
     void deleteLike_Success() {
         // given
         CustomUser2Member user = new CustomUser2Member(
-            new CustomUserDetails(member.getMemberId(), "", "",
+            new CustomUserDetails(feedbackWriter.getMemberId(), "", "",
                 "", "", MemberRole.USER, MemberStatus.ACTIVITY));
 
-        likeRepository.save(Like.create(member, feedback));
+        likeRepository.save(Like.create(feedbackWriter, feedback));
 
         // when
         likeService.deleteLike(feedback.getFeedbackId(), user);
 
         // then
         String deleteLike = redisTemplate.opsForValue()
-            .get(generateKey(feedback.getFeedbackId(), member.getMemberId()));
+            .get(generateKey(feedback.getFeedbackId(), feedbackWriter.getMemberId()));
         assertThat(deleteLike).isEqualTo("CANCEL");
         redisTemplate.delete(
-            generateKey(feedback.getFeedbackId(), member.getMemberId())
+            generateKey(feedback.getFeedbackId(), feedbackWriter.getMemberId())
         );
     }
 
@@ -153,7 +148,7 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
     void deleteLike_Failure() {
         // given
         CustomUser2Member user = new CustomUser2Member(
-            new CustomUserDetails(member.getMemberId(), "", "",
+            new CustomUserDetails(feedbackWriter.getMemberId(), "", "",
                 "", "", MemberRole.USER, MemberStatus.ACTIVITY));
 
         // when & then
@@ -170,10 +165,10 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
         // given
         Long feedbackId = feedback.getFeedbackId();
         CustomUser2Member user = new CustomUser2Member(
-            new CustomUserDetails(member.getMemberId(), "", "",
+            new CustomUserDetails(feedbackWriter.getMemberId(), "", "",
                 "", "", MemberRole.USER, MemberStatus.ACTIVITY));
 
-        likeRepository.save(Like.create(member, feedback));
+        likeRepository.save(Like.create(feedbackWriter, feedback));
 
         // when
         LikeExistResponse actual = likeService.existsLike(feedbackId, user);
@@ -188,7 +183,7 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
         // given
         Long feedbackId = feedback.getFeedbackId();
         CustomUser2Member user = new CustomUser2Member(
-            new CustomUserDetails(member.getMemberId(), "", "",
+            new CustomUserDetails(feedbackWriter.getMemberId(), "", "",
                 "", "", MemberRole.USER, MemberStatus.ACTIVITY));
 
         // when
@@ -204,7 +199,7 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
         // given
         Long feedbackId = feedback.getFeedbackId();
         CustomUser2Member user = new CustomUser2Member(
-            new CustomUserDetails(member.getMemberId(), "", "",
+            new CustomUserDetails(feedbackWriter.getMemberId(), "", "",
                 "", "", MemberRole.USER, MemberStatus.ACTIVITY));
 
         likeService.addLike(feedbackId, user);
@@ -222,10 +217,10 @@ class LikeServiceTest extends IntegrationTest implements RedisTestContainer {
         // given
         Long feedbackId = feedback.getFeedbackId();
         CustomUser2Member user = new CustomUser2Member(
-            new CustomUserDetails(member.getMemberId(), "", "",
+            new CustomUserDetails(feedbackWriter.getMemberId(), "", "",
                 "", "", MemberRole.USER, MemberStatus.ACTIVITY));
 
-        likeRepository.save(Like.create(member, feedback));
+        likeRepository.save(Like.create(feedbackWriter, feedback));
         likeService.deleteLike(feedbackId, user);
 
         // when

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/fixture/TestMemberFactory.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/fixture/TestMemberFactory.java
@@ -7,50 +7,46 @@ import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
 public class TestMemberFactory {
 
     public static Member createActiveUser(Long id, String email, String nickname) {
-        return Member.builder()
-            .memberId(id).email(email).password("123456").role(MemberRole.USER)
-            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-            .profileImageUrl("https://test-image.com/test-123131")
+        return baseBuilder(email, nickname, MemberRole.USER)
+            .memberId(id)
             .build();
     }
 
     public static Member createActiveUser(String email, String nickname) {
-        return Member.builder()
-            .email(email).password("123456").role(MemberRole.USER)
-            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-            .profileImageUrl("https://test-image.com/test-123131")
+        return baseBuilder(email, nickname, MemberRole.USER)
             .build();
     }
 
     public static Member createWithdrawalUser(Long id, String email, String nickname) {
-        return Member.builder()
-            .memberId(id).email(email).password("123456").role(MemberRole.USER)
-            .nickname(nickname).memberStatus(MemberStatus.WITHDRAWAL)
-            .profileImageUrl("https://test-image.com/test-123131")
+        return baseBuilder(email, nickname, MemberRole.USER)
+            .memberId(id)
+            .memberStatus(MemberStatus.WITHDRAWAL)
             .build();
     }
 
     public static Member createWithdrawalUser(String email, String nickname) {
-        return Member.builder()
-            .email(email).password("123456").role(MemberRole.USER)
-            .nickname(nickname).memberStatus(MemberStatus.WITHDRAWAL)
-            .profileImageUrl("https://test-image.com/test-123131")
+        return baseBuilder(email, nickname, MemberRole.USER)
+            .memberStatus(MemberStatus.WITHDRAWAL)
             .build();
     }
 
     public static Member createAdmin(Long id, String email, String nickname) {
-        return Member.builder()
-            .memberId(id).email(email).password("123456").role(MemberRole.ADMIN)
-            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-            .profileImageUrl("https://test-image.com/test-123131")
+        return baseBuilder(email, nickname, MemberRole.ADMIN)
+            .memberId(id)
             .build();
     }
 
     public static Member createAdmin(String email, String nickname) {
-        return Member.builder()
-            .email(email).password("123456").role(MemberRole.ADMIN)
-            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-            .profileImageUrl("https://test-image.com/test-123131")
+        return baseBuilder(email, nickname, MemberRole.ADMIN)
             .build();
+    }
+
+    private static Member.MemberBuilder baseBuilder(
+        String email, String nickname, MemberRole role
+    ) {
+        return Member.builder()
+            .email(email).password("123456").role(role)
+            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
+            .profileImageUrl("https://test-image.com/test-123131");
     }
 }

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/fixture/TestMemberFactory.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/fixture/TestMemberFactory.java
@@ -1,0 +1,56 @@
+package org.programmers.signalbuddyfinal.domain.member.fixture;
+
+import org.programmers.signalbuddyfinal.domain.member.entity.Member;
+import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
+import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+
+public class TestMemberFactory {
+
+    public static Member createActiveUser(Long id, String email, String nickname) {
+        return Member.builder()
+            .memberId(id).email(email).password("123456").role(MemberRole.USER)
+            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
+            .profileImageUrl("https://test-image.com/test-123131")
+            .build();
+    }
+
+    public static Member createActiveUser(String email, String nickname) {
+        return Member.builder()
+            .email(email).password("123456").role(MemberRole.USER)
+            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
+            .profileImageUrl("https://test-image.com/test-123131")
+            .build();
+    }
+
+    public static Member createWithdrawalUser(Long id, String email, String nickname) {
+        return Member.builder()
+            .memberId(id).email(email).password("123456").role(MemberRole.USER)
+            .nickname(nickname).memberStatus(MemberStatus.WITHDRAWAL)
+            .profileImageUrl("https://test-image.com/test-123131")
+            .build();
+    }
+
+    public static Member createWithdrawalUser(String email, String nickname) {
+        return Member.builder()
+            .email(email).password("123456").role(MemberRole.USER)
+            .nickname(nickname).memberStatus(MemberStatus.WITHDRAWAL)
+            .profileImageUrl("https://test-image.com/test-123131")
+            .build();
+    }
+
+    public static Member createAdmin(Long id, String email, String nickname) {
+        return Member.builder()
+            .memberId(id).email(email).password("123456").role(MemberRole.ADMIN)
+            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
+            .profileImageUrl("https://test-image.com/test-123131")
+            .build();
+    }
+
+    public static Member createAdmin(String email, String nickname) {
+        return Member.builder()
+            .email(email).password("123456").role(MemberRole.ADMIN)
+            .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
+            .profileImageUrl("https://test-image.com/test-123131")
+            .build();
+    }
+}

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/notification/service/FcmServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/notification/service/FcmServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.programmers.signalbuddyfinal.domain.member.entity.Member;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddyfinal.domain.member.fixture.TestMemberFactory;
 import org.programmers.signalbuddyfinal.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddyfinal.domain.notification.dto.FcmMessage;
 import org.programmers.signalbuddyfinal.domain.notification.dto.FcmMessage.Notification;
@@ -57,7 +58,9 @@ class FcmServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        member = saveMember("test email", "tester");
+        member = memberRepository.save(
+            TestMemberFactory.createActiveUser("test email", "tester")
+        );
         fcmToken = saveFcmToken("test token", member);
     }
 
@@ -88,7 +91,9 @@ class FcmServiceTest extends IntegrationTest {
     void sendMessageNotDeviceToken_Success() {
         // Given
         FcmMessage request = getFcmMessage("test title", "test body");
-        Member otherMember = saveMember("test1 email", "other tester");
+        Member otherMember = memberRepository.save(
+            TestMemberFactory.createActiveUser("test1 email", "other tester")
+        );
         CustomUser2Member user = getCurrentMember(otherMember.getMemberId());
 
         when(firebaseMessaging.sendEachForMulticastAsync(any(MulticastMessage.class)))
@@ -189,7 +194,9 @@ class FcmServiceTest extends IntegrationTest {
     void deleteDeviceToken_Failure() {
         // Given
         String deviceTokenUuid = fcmToken.getFcmTokenUuid();
-        Member otherMember = saveMember("other email", "other");
+        Member otherMember = memberRepository.save(
+            TestMemberFactory.createActiveUser("other email", "other")
+        );
         CustomUser2Member user = getCurrentMember(otherMember.getMemberId());
 
         // When & Then
@@ -199,13 +206,6 @@ class FcmServiceTest extends IntegrationTest {
             assertThat(e.getErrorCode())
                 .isEqualTo(FcmErrorCode.FCM_TOKEN_ELIMINATOR_NOT_AUTHORIZED);
         }
-    }
-
-    private Member saveMember(String email, String nickname) {
-        return memberRepository.save(
-            Member.builder().email(email).password("123456").role(MemberRole.USER)
-                .nickname(nickname).memberStatus(MemberStatus.ACTIVITY)
-                .profileImageUrl("https://test-image.com/test-123131").build());
     }
 
     private FcmToken saveFcmToken(String deviceToken, Member member) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #267 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> `Member` 객체에 대한 테스트 픽스처 생성에 관한 코드의 중복을 줄였습니다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> `Member` Test Fixture를 사용하는 곳이 워낙 많아 다른 분들 작업과 충돌날 가능성이 높았습니다. 
> 그래서 제가 작성한 코드만 리팩터링을 진행했습니다.

> 이제부터 테스트 코드에서 `Member` 객체를 사용해야 할 때 `TestMemberFactory` 클래스의 정적 팩터리 메서드를 사용해주시면 됩니다!

