### PR TITLE
[Fix] GitHub runner에서 testcontainers가 docker를 찾지 못하는 문제 해결

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: JDK 17 설치
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,10 +60,9 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-    testImplementation platform('org.testcontainers:testcontainers-bom:1.21.4')
-    testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.testcontainers:mariadb'
+    testImplementation 'org.testcontainers:testcontainers:1.21.4'
+    testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
+    testImplementation 'org.testcontainers:mariadb:1.21.4'
 
     // Hibernate-spatial
     implementation 'org.hibernate:hibernate-spatial:6.6.3.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-    testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation "org.testcontainers:mariadb:1.19.7"
+    testImplementation 'org.testcontainers:testcontainers:2.0.3'
+    testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
+    testImplementation 'org.testcontainers:mariadb:1.21.4'
     testImplementation 'org.springframework.security:spring-security-test'
 
     // Hibernate-spatial

--- a/build.gradle
+++ b/build.gradle
@@ -58,11 +58,12 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-    testImplementation 'org.testcontainers:testcontainers:2.0.3'
-    testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
-    testImplementation 'org.testcontainers:mariadb:1.21.4'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation platform('org.testcontainers:testcontainers-bom:2.0.3')
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mariadb'
 
     // Hibernate-spatial
     implementation 'org.hibernate:hibernate-spatial:6.6.3.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-    testImplementation platform('org.testcontainers:testcontainers-bom:2.0.3')
+    testImplementation platform('org.testcontainers:testcontainers-bom:1.21.4')
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mariadb'

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-    testImplementation 'org.testcontainers:testcontainers:1.21.4'
+    testImplementation 'org.testcontainers:testcontainers:2.0.3'
     testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
     testImplementation 'org.testcontainers:mariadb:1.21.4'
 

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminFeedbackControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminFeedbackControllerTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.admin.service.AdminFeedbackService;
@@ -49,7 +50,6 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 @WebMvcTest(AdminFeedbackController.class)
 class AdminFeedbackControllerTest extends ControllerTest {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminMemberControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminMemberControllerTest.java
@@ -97,7 +97,7 @@ class AdminMemberControllerTest extends ControllerTest {
 
     @DisplayName("회원 필터링 조회")
     @Test
-    public void FilteredMember() throws Exception {
+    void FilteredMember() throws Exception {
         final MemberFilterRequest filter = MemberFilterRequest.builder()
             .role(MemberRole.USER)
             .status(MemberStatus.ACTIVITY)

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminMemberControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminMemberControllerTest.java
@@ -3,7 +3,9 @@ package org.programmers.signalbuddyfinal.domain.admin.controller;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.pageResponseFormat;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -15,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.admin.dto.AdminMemberResponse;
@@ -30,12 +33,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
-
-import static org.mockito.BDDMockito.*;
-
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 
 @WebMvcTest(AdminMemberController.class)
 class AdminMemberControllerTest extends ControllerTest {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminPostItControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminPostItControllerTest.java
@@ -50,7 +50,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(AdminPostItController.class)
-public class AdminPostItControllerTest extends ControllerTest {
+class AdminPostItControllerTest extends ControllerTest {
 
     private final String tag = "Admin API";
 
@@ -233,8 +233,8 @@ public class AdminPostItControllerTest extends ControllerTest {
                     .param("startDate", filter.getStartDate().toString())
                     .param("endDate", filter.getEndDate().toString())
                     .param("search", filter.getSearch())
-                    .param("danger", filter.getSearch().toString())
-                    .param("deleted", filter.getSearch().toString())
+                    .param("danger", filter.getSearch())
+                    .param("deleted", filter.getSearch())
                     .header("Accept", "application/json"))
             .andExpect(status().isOk())
             .andDo(print())

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminPostItControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/admin/controller/AdminPostItControllerTest.java
@@ -27,6 +27,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.admin.dto.AdminPostItResponse;
@@ -47,7 +48,6 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 @WebMvcTest(AdminPostItController.class)
 public class AdminPostItControllerTest extends ControllerTest {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.air_quality.dto.AirQualityResponse;
@@ -20,7 +21,6 @@ import org.programmers.signalbuddyfinal.domain.air_quality.service.AirQualitySer
 import org.programmers.signalbuddyfinal.global.support.ControllerTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 @WebMvcTest(AirQualityController.class)
 public class AirQualityControllerTest extends ControllerTest {
 

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/air_quality/controller/AirQualityControllerTest.java
@@ -22,7 +22,7 @@ import org.programmers.signalbuddyfinal.global.support.ControllerTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @WebMvcTest(AirQualityController.class)
-public class AirQualityControllerTest extends ControllerTest {
+class AirQualityControllerTest extends ControllerTest {
 
     private final String tag = "AirQuality API";
 

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/comment/controller/CommentControllerTest.java
@@ -28,6 +28,7 @@ import com.epages.restdocs.apispec.SimpleType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.comment.dto.CommentRequest;
@@ -49,7 +50,6 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 @WebMvcTest(CommentController.class)
 class CommentControllerTest extends ControllerTest {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_report/controller/FeedbackReportControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_report/controller/FeedbackReportControllerTest.java
@@ -29,6 +29,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.feedback_report.dto.FeedbackReportRequest;
@@ -56,7 +57,6 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 @WebMvcTest(FeedbackReportController.class)
 class FeedbackReportControllerTest extends ControllerTest {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_summary/controller/FeedbackSummaryControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/feedback_summary/controller/FeedbackSummaryControllerTest.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.feedback.entity.enums.FeedbackCategory;
@@ -36,7 +37,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 @WebMvcTest(FeedbackSummaryController.class)
 class FeedbackSummaryControllerTest extends ControllerTest {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/like/controller/LikeControllerTest.java
@@ -21,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.like.dto.LikeExistResponse;
@@ -33,7 +34,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 @WebMvcTest(LikeController.class)
 class LikeControllerTest extends ControllerTest {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/member/controller/MemberControllerTest.java
@@ -36,6 +36,7 @@ import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.bookmark.dto.BookmarkRequest;
@@ -79,7 +80,6 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.multipart.MultipartFile;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 @WebMvcTest(MemberController.class)
 @Import(WebConfig.class) // @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO) 적용

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItControllerTest.java
@@ -56,7 +56,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.multipart.MultipartFile;
 
 @WebMvcTest(PostItController.class)
-public class PostItControllerTest extends ControllerTest {
+class PostItControllerTest extends ControllerTest {
 
     @MockitoBean
     private PostItService postItService;
@@ -70,7 +70,7 @@ public class PostItControllerTest extends ControllerTest {
     @DisplayName("포스트잇 등록")
     @Test
     @WithMockCustomUser
-    public void createPostIt() throws Exception {
+    void createPostIt() throws Exception {
 
         PostItCreateRequest request = PostItCreateRequest.builder()
             .danger(Danger.DANGER)
@@ -200,7 +200,7 @@ public class PostItControllerTest extends ControllerTest {
     @Test
     @DisplayName("포스트잇 수정")
     @WithMockCustomUser
-    public void updatePostIt() throws Exception {
+    void updatePostIt() throws Exception {
 
         PostItRequest request = PostItRequest.builder()
             .danger(Danger.DANGER)
@@ -333,12 +333,7 @@ public class PostItControllerTest extends ControllerTest {
     @Test
     @DisplayName("포스트잇 삭제")
     @WithMockCustomUser
-    public void deletePostIt() throws Exception {
-
-        CustomUserDetails customUserDetails = new CustomUserDetails(1L, "user1@gmamil.com", "12345",
-            "url2.jpg", "user1", MemberRole.USER, MemberStatus.ACTIVITY);
-        CustomUser2Member user = new CustomUser2Member(customUserDetails);
-
+    void deletePostIt() throws Exception {
         doNothing().when(postItService).deletePostIt(anyLong(), any(CustomUser2Member.class));
 
         final ResultActions result = mockMvc.perform(
@@ -372,7 +367,7 @@ public class PostItControllerTest extends ControllerTest {
     @Test
     @DisplayName("포스트잇 해결")
     @WithMockCustomUser
-    public void completePostIt() throws Exception {
+    void completePostIt() throws Exception {
         PostItResponse postItResponse = createResponse(1L);
 
         given(postItService.completePostIt(anyLong())).willReturn(postItResponse);

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/postit/controller/PostItControllerTest.java
@@ -5,7 +5,6 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithNam
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.programmers.signalbuddyfinal.global.support.RestDocsFormatGenerators.commonResponseFormat;
@@ -19,19 +18,18 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
 import java.time.LocalDateTime;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.member.entity.enums.MemberRole;
@@ -56,7 +54,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.multipart.MultipartFile;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 @WebMvcTest(PostItController.class)
 public class PostItControllerTest extends ControllerTest {

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/recentpath/controller/RecentPathControllerTest.java
@@ -20,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
 import java.time.LocalDateTime;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.recentpath.dto.RecentPathLinkRequest;
@@ -31,9 +32,8 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
-@WebMvcTest(RecentPathController.class)
+@WebMvcTest(org.programmers.signalbuddyfinal.domain.recentpath.controller.RecentPathController.class)
 class RecentPathControllerTest extends ControllerTest {
 
     private final String tag = "RecentPath API";

--- a/src/test/java/org/programmers/signalbuddyfinal/domain/term/controller/TermControllerTest.java
+++ b/src/test/java/org/programmers/signalbuddyfinal/domain/term/controller/TermControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddyfinal.domain.term.dto.TermResponse;
@@ -24,7 +25,6 @@ import org.programmers.signalbuddyfinal.global.support.ControllerTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 @WebMvcTest(TermController.class)
 class TermControllerTest extends ControllerTest {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #293 

## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> Docker Engine 29버전부터 기존 Testcontainers가 도커 환경을 찾지 못하는 문제를 해결했습니다. ([해당 에러에 대한 글](https://forums.docker.com/t/testcontainer-stopped-working-after-updating-docker-desktop-to-v4-56-0/150823))
> SonarQube가 검사해준 뒤 문제 있는 코드를 리팩터링 했습니다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 
